### PR TITLE
Extract shared code from page JS files into common.js

### DIFF
--- a/src/main/resources/static/js/account.js
+++ b/src/main/resources/static/js/account.js
@@ -127,9 +127,7 @@ function loadTransactions(id) {
 function renderAccountHero(account) {
     var currency      = (account.currency || "EUR").toUpperCase();
     var balance       = parseFloat(account.balance) || 0;
-    var typeName      = (account.accountType || "Account")
-        .replace(/_/g, " ")
-        .replace(/\b\w/g, function (c) { return c.toUpperCase(); });
+    var typeName      = formatAccountType(account.accountType);
     var displayNumber = maskAccount(account.number);
     var iconClass     = getTypeIconClass(account.accountType || "");
 
@@ -157,15 +155,6 @@ function renderAccountHero(account) {
     $("#txPageHeader").show();
     $("#summaryStrip").show();
     $("#transactionsSection").show();
-}
-
-function getTypeIconClass(type) {
-    var t = (type || "").toUpperCase();
-    if (t === "CHECKING")         return "blue";
-    if (t === "SAVING")           return "green";
-    if (t === "BUSINESS")         return "purple";
-    if (t === "FOREIGN_CURRENCY") return "amber";
-    return "blue";
 }
 
 // ============================================================
@@ -196,7 +185,7 @@ function renderPage() {
     var start = (State.currentPage - 1) * PAGE_SIZE;
     var page  = State.filtered.slice(start, start + PAGE_SIZE);
     renderTransactionRows(page);
-    renderPagination();
+    renderPagination(State);
 }
 
 // ============================================================
@@ -252,13 +241,8 @@ function renderTransactionRows(transactions) {
         var formatted = sign + formatCurrency(amount, currency);
         var status    = "completed";
 
-        var fromLabel    = (tx.bankAccountFrom && tx.bankAccountFrom.number) ? maskAccount(tx.bankAccountFrom.number) : "\u2014";
-        var toLabel      = (tx.bankAccountTo && tx.bankAccountTo.number) ? maskAccount(tx.bankAccountTo.number) : "\u2014";
-        var counterparty = isIn ? ("From " + maskAccount(fromLabel)) : ("To " + maskAccount(toLabel));
-
-        var arrowSvg = isIn
-            ? '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>'
-            : '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>';
+        var counterparty = buildCounterpartyLabel(tx, isIn);
+        var arrowSvg    = getDirectionArrowSvg(isIn, 20);
 
         var row =
             '<tr class="row-' + dir + '" data-tx-id="' + escapeHtml(String(tx.id)) + '">' +
@@ -282,21 +266,6 @@ function renderTransactionRows(transactions) {
 
         $tbody.append(row);
     });
-}
-
-// ============================================================
-// RENDER: Pagination
-// ============================================================
-
-function renderPagination() {
-    if (State.filtered.length === 0) {
-        $("#pagination").hide();
-        return;
-    }
-    $("#pagination").show();
-    $("#paginationInfo").text("Page " + State.currentPage + " of " + State.totalPages);
-    $("#btnPrevPage").prop("disabled", State.currentPage <= 1);
-    $("#btnNextPage").prop("disabled", State.currentPage >= State.totalPages);
 }
 
 // ============================================================
@@ -328,27 +297,9 @@ function renderModal(tx) {
     var currency = (tx.currency || (State.account ? State.account.currency : "EUR") || "EUR").toUpperCase();
     var sign     = isIn ? "+" : "-";
 
-    var arrowSvg = isIn
-        ? '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>'
-        : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>';
-
-    var fields = [];
-    addField(fields, "Transaction ID", tx.id);
-    addField(fields, "Description",    tx.description, true);
-    addField(fields, "Date",           formatDateTime(tx.createDate));
-    addField(fields, "From Account",   tx.bankAccountFrom ? maskAccount(tx.bankAccountFrom.number) || formatId(tx.bankAccountFrom.id) : null);
-    addField(fields, "To Account",     tx.bankAccountTo ? maskAccount(tx.bankAccountTo.number) || formatId(tx.bankAccountTo.id) : null);
-    addField(fields, "Currency",       currency);
-
-    var gridHtml = "";
-    fields.forEach(function (f) {
-        var cls = f.fullWidth ? " full-width" : "";
-        gridHtml +=
-            '<div class="detail-item' + cls + '">' +
-                '<div class="detail-label">' + escapeHtml(f.label) + '</div>' +
-                '<div class="detail-value">' + escapeHtml(String(f.value)) + '</div>' +
-            '</div>';
-    });
+    var arrowSvg = getDirectionArrowSvg(isIn, 18);
+    var fields   = buildTransactionDetailFields(tx, currency);
+    var gridHtml = renderDetailGrid(fields);
 
     var html =
         '<div class="detail-direction">' +
@@ -363,10 +314,6 @@ function renderModal(tx) {
 
     $("#modalBody").html(html);
     $("#modalOverlay").addClass("open");
-}
-
-function closeModal() {
-    $("#modalOverlay").removeClass("open");
 }
 
 // ============================================================
@@ -385,7 +332,7 @@ $(document).ready(function () {
         if (State.currentPage > 1) {
             State.currentPage--;
             renderPage();
-            scrollToTable();
+            scrollToTable("#transactionsSection");
         }
     });
 
@@ -393,7 +340,7 @@ $(document).ready(function () {
         if (State.currentPage < State.totalPages) {
             State.currentPage++;
             renderPage();
-            scrollToTable();
+            scrollToTable("#transactionsSection");
         }
     });
 
@@ -402,17 +349,5 @@ $(document).ready(function () {
         openDetail(txId);
     });
 
-    $("#modalClose, #modalCloseBtn").on("click", closeModal);
-    $("#modalOverlay").on("click", function (e) {
-        if (e.target === this) closeModal();
-    });
-    $(document).on("keydown", function (e) {
-        if (e.key === "Escape") closeModal();
-    });
+    initModalClose();
 });
-
-function scrollToTable() {
-    $("html, body").animate({
-        scrollTop: $("#transactionsSection").offset().top - 80
-    }, 250);
-}

--- a/src/main/resources/static/js/accounts.js
+++ b/src/main/resources/static/js/accounts.js
@@ -100,9 +100,7 @@ function renderAccountRows(accounts) {
         var id            = account.id;
         var currency      = (account.currency || "EUR").toUpperCase();
         var balance       = parseFloat(account.balance) || 0;
-        var typeName      = (account.accountType || "Account")
-            .replace(/_/g, " ")
-            .replace(/\b\w/g, function (c) { return c.toUpperCase(); });
+        var typeName      = formatAccountType(account.accountType);
         var displayNumber = maskAccount(account.number);
         var iconClass     = getTypeIconClass(account.accountType || "");
 
@@ -177,15 +175,6 @@ function renderAccountRows(accounts) {
 
     showLoading(false);
     $list.show();
-}
-
-function getTypeIconClass(type) {
-    var t = (type || "").toUpperCase();
-    if (t === "CHECKING")         return "blue";
-    if (t === "SAVING")           return "green";
-    if (t === "BUSINESS")         return "purple";
-    if (t === "FOREIGN_CURRENCY") return "amber";
-    return "blue";
 }
 
 // ============================================================

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -117,6 +117,107 @@ function formatId(id) {
 }
 
 // ============================================================
+// ACCOUNT HELPERS
+// ============================================================
+
+function getTypeIconClass(type) {
+    var t = (type || "").toUpperCase();
+    if (t === "CHECKING")         return "blue";
+    if (t === "SAVING")           return "green";
+    if (t === "BUSINESS")         return "purple";
+    if (t === "FOREIGN_CURRENCY") return "amber";
+    return "blue";
+}
+
+function formatAccountType(type) {
+    return (type || "Account")
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, function (c) { return c.toUpperCase(); });
+}
+
+// ============================================================
+// TRANSACTION HELPERS
+// ============================================================
+
+function getDirectionArrowSvg(isIncoming, size) {
+    var s = size || 20;
+    if (isIncoming) {
+        return '<svg width="' + s + '" height="' + s + '" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>';
+    }
+    return '<svg width="' + s + '" height="' + s + '" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>';
+}
+
+function buildCounterpartyLabel(tx, isIncoming) {
+    var fromLabel = (tx.bankAccountFrom && tx.bankAccountFrom.number) ? maskAccount(tx.bankAccountFrom.number) : "\u2014";
+    var toLabel   = (tx.bankAccountTo && tx.bankAccountTo.number) ? maskAccount(tx.bankAccountTo.number) : "\u2014";
+    return isIncoming ? ("From " + fromLabel) : ("To " + toLabel);
+}
+
+function buildTransactionDetailFields(tx, currency) {
+    var fields = [];
+    addField(fields, "Transaction ID", tx.id);
+    addField(fields, "Description",    tx.description, true);
+    addField(fields, "Date",           formatDateTime(tx.createDate));
+    addField(fields, "From Account",   tx.bankAccountFrom ? maskAccount(tx.bankAccountFrom.number) || formatId(tx.bankAccountFrom.id) : null);
+    addField(fields, "To Account",     tx.bankAccountTo ? maskAccount(tx.bankAccountTo.number) || formatId(tx.bankAccountTo.id) : null);
+    addField(fields, "Currency",       (currency || "").toUpperCase());
+    return fields;
+}
+
+function renderDetailGrid(fields) {
+    var html = "";
+    fields.forEach(function (f) {
+        var cls = f.fullWidth ? " full-width" : "";
+        html +=
+            '<div class="detail-item' + cls + '">' +
+                '<div class="detail-label">' + escapeHtml(f.label) + '</div>' +
+                '<div class="detail-value">' + escapeHtml(String(f.value)) + '</div>' +
+            '</div>';
+    });
+    return html;
+}
+
+// ============================================================
+// MODAL HELPERS
+// ============================================================
+
+function closeModal() {
+    $("#modalOverlay").removeClass("open");
+}
+
+function initModalClose() {
+    $("#modalClose, #modalCloseBtn").on("click", closeModal);
+    $("#modalOverlay").on("click", function (e) {
+        if (e.target === this) closeModal();
+    });
+    $(document).on("keydown", function (e) {
+        if (e.key === "Escape") closeModal();
+    });
+}
+
+// ============================================================
+// PAGINATION & SCROLL
+// ============================================================
+
+function renderPagination(state) {
+    if (state.filtered.length === 0) {
+        $("#pagination").hide();
+        return;
+    }
+    $("#pagination").show();
+    $("#paginationInfo").text("Page " + state.currentPage + " of " + state.totalPages);
+    $("#btnPrevPage").prop("disabled", state.currentPage <= 1);
+    $("#btnNextPage").prop("disabled", state.currentPage >= state.totalPages);
+}
+
+function scrollToTable(selector) {
+    var $el = $(selector);
+    if ($el.length) {
+        $("html, body").animate({ scrollTop: $el.offset().top - 80 }, 250);
+    }
+}
+
+// ============================================================
 // PROFILE NAVIGATION
 // ============================================================
 

--- a/src/main/resources/static/js/dashboard.js
+++ b/src/main/resources/static/js/dashboard.js
@@ -52,9 +52,7 @@ var DashboardRenderer = {
             var balance = parseFloat(account.balance) || 0;
             var formattedBalance = formatCurrency(balance, currency);
             var displayNumber = maskAccount(account.number);
-            var typeName = (account.accountType || "Account")
-                .replace(/_/g, " ")
-                .replace(/\b\w/g, function (c) { return c.toUpperCase(); });
+            var typeName = formatAccountType(account.accountType);
 
             var footerStatLabel, footerStatValue;
             if (isCredit) {

--- a/src/main/resources/static/js/new-transaction.js
+++ b/src/main/resources/static/js/new-transaction.js
@@ -406,9 +406,7 @@ function populateAccountDropdowns(accounts) {
 }
 
 function buildAccountLabel(acct) {
-    var type = (acct.accountType || "Account")
-        .replace(/_/g, " ")
-        .replace(/\b\w/g, function (c) { return c.toUpperCase(); });
+    var type = formatAccountType(acct.accountType);
     var num  = maskAccount(acct.number);
     var bal  = formatCurrency(acct.balance, acct.currency || "EUR");
     return type + " " + num + "  \u2014  " + bal;

--- a/src/main/resources/static/js/transactions.js
+++ b/src/main/resources/static/js/transactions.js
@@ -182,7 +182,7 @@ function renderPage() {
     var page  = State.filtered.slice(start, start + PAGE_SIZE);
 
     renderTransactionRows(page);
-    renderPagination();
+    renderPagination(State);
 }
 
 // ============================================================
@@ -213,13 +213,8 @@ function renderTransactionRows(transactions) {
         var formatted = sign + formatCurrency(amount, currency);
         var status    = "completed";
 
-        var fromLabel = (tx.bankAccountFrom && tx.bankAccountFrom.number) ? maskAccount(tx.bankAccountFrom.number) : "\u2014";
-        var toLabel   = (tx.bankAccountTo && tx.bankAccountTo.number) ? maskAccount(tx.bankAccountTo.number) : "\u2014";
-        var counterparty = isIn ? ("From " + maskAccount(fromLabel)) : ("To " + maskAccount(toLabel));
-
-        var arrowSvg = isIn
-            ? '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>'
-            : '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>';
+        var counterparty = buildCounterpartyLabel(tx, isIn);
+        var arrowSvg    = getDirectionArrowSvg(isIn, 20);
 
         var row =
             '<tr class="row-' + dir + '" data-tx-id="' + escapeHtml(String(tx.id)) + '">' +
@@ -261,21 +256,6 @@ function renderSummary(list) {
     $("#totalCount").text(list.length);
     $("#totalIncoming").text(formatCurrency(inTotal, "EUR"));
     $("#totalOutgoing").text(formatCurrency(outTotal, "EUR"));
-}
-
-// ============================================================
-// RENDER: Pagination
-// ============================================================
-
-function renderPagination() {
-    if (State.filtered.length === 0) {
-        $("#pagination").hide();
-        return;
-    }
-    $("#pagination").show();
-    $("#paginationInfo").text("Page " + State.currentPage + " of " + State.totalPages);
-    $("#btnPrevPage").prop("disabled", State.currentPage <= 1);
-    $("#btnNextPage").prop("disabled", State.currentPage >= State.totalPages);
 }
 
 // ============================================================
@@ -326,28 +306,9 @@ function renderModal(tx) {
     var currency = tx.currency || "EUR";
     var sign     = isIn ? "+" : "-";
 
-    var arrowSvg = isIn
-        ? '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>'
-        : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>';
-
-    var fields = [];
-
-    addField(fields, "Transaction ID",   tx.id);
-    addField(fields, "Description",      tx.description, true);
-    addField(fields, "Date",             formatDateTime(tx.createDate));
-    addField(fields, "From Account",     tx.bankAccountFrom ? maskAccount(tx.bankAccountFrom.number) || formatId(tx.bankAccountFrom.id) : null);
-    addField(fields, "To Account",       tx.bankAccountTo ? maskAccount(tx.bankAccountTo.number) || formatId(tx.bankAccountTo.id) : null);
-    addField(fields, "Currency",         (currency || "").toUpperCase());
-
-    var gridHtml = "";
-    fields.forEach(function (f) {
-        var cls = f.fullWidth ? ' full-width' : '';
-        gridHtml +=
-            '<div class="detail-item' + cls + '">' +
-                '<div class="detail-label">' + escapeHtml(f.label) + '</div>' +
-                '<div class="detail-value">' + escapeHtml(String(f.value)) + '</div>' +
-            '</div>';
-    });
+    var arrowSvg = getDirectionArrowSvg(isIn, 18);
+    var fields   = buildTransactionDetailFields(tx, currency);
+    var gridHtml = renderDetailGrid(fields);
 
     var html =
         '<div class="detail-direction">' +
@@ -367,10 +328,6 @@ function renderModal(tx) {
     $("#modalOverlay").addClass("open");
 }
 
-function closeModal() {
-    $("#modalOverlay").removeClass("open");
-}
-
 // ============================================================
 // EVENT HANDLERS
 // ============================================================
@@ -387,7 +344,7 @@ $(document).ready(function () {
         if (State.currentPage > 1) {
             State.currentPage--;
             renderPage();
-            scrollToTable();
+            scrollToTable(".transactions-section");
         }
     });
 
@@ -395,7 +352,7 @@ $(document).ready(function () {
         if (State.currentPage < State.totalPages) {
             State.currentPage++;
             renderPage();
-            scrollToTable();
+            scrollToTable(".transactions-section");
         }
     });
 
@@ -405,17 +362,5 @@ $(document).ready(function () {
         openDetail(txId);
     });
 
-    $("#modalClose, #modalCloseBtn").on("click", closeModal);
-    $("#modalOverlay").on("click", function (e) {
-        if (e.target === this) closeModal();
-    });
-    $(document).on("keydown", function (e) {
-        if (e.key === "Escape") closeModal();
-    });
+    initModalClose();
 });
-
-function scrollToTable() {
-    $("html, body").animate({
-        scrollTop: $(".transactions-section").offset().top - 80
-    }, 250);
-}


### PR DESCRIPTION
Move duplicated functions and patterns into common.js to reduce duplication across 6 frontend files (-158 lines, +124 lines):

- getTypeIconClass(): identical in account.js + accounts.js
- formatAccountType(): same 3-line pattern in 4 files
- getDirectionArrowSvg(): 4 identical SVG blocks across 2 files
- closeModal() + initModalClose(): identical in 2 files
- renderDetailGrid(): identical grid loop in 2 files
- buildTransactionDetailFields(): identical field building in 2 files
- buildCounterpartyLabel(): identical in 2 files (fixes double-masking)
- scrollToTable(): near-identical in 2 files (parameterized selector)
- renderPagination(): identical in 2 files (parameterized state)

https://claude.ai/code/session_01MazsdaUz6JG4DN1tfuo7yX