### PR TITLE
Add Employee and Admin profile support to user-profile page

### DIFF
--- a/src/main/java/com/alex/controller/EmployeeController.java
+++ b/src/main/java/com/alex/controller/EmployeeController.java
@@ -1,9 +1,14 @@
 package com.alex.controller;
 
+import com.alex.dto.AdminProfile;
 import com.alex.dto.Employee;
+import com.alex.dto.EmployeeProfile;
 import com.alex.dto.Password;
+import com.alex.dto.UserAccount;
 import com.alex.exception.EmployeeNotFoundRuntimeException;
+import com.alex.exception.UserAccountNotFoundRuntimeException;
 import com.alex.service.IEmployeeService;
+import com.alex.service.IUserAccountService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,9 +20,11 @@ import java.util.List;
 public class EmployeeController {
 
     private final IEmployeeService employeeService;
+    private final IUserAccountService userAccountService;
 
-    public EmployeeController(IEmployeeService employeeService) {
+    public EmployeeController(IEmployeeService employeeService, IUserAccountService userAccountService) {
         this.employeeService = employeeService;
+        this.userAccountService = userAccountService;
     }
 
     @PostMapping(consumes = "application/json")
@@ -56,5 +63,26 @@ public class EmployeeController {
                                                        @RequestBody Password password) {
         employeeService.updatePassword(employeeId, password);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping(path = "/profile")
+    public ResponseEntity<EmployeeProfile> findEmployeeProfile(@RequestParam("userAccountId") Long userAccountId) {
+        EmployeeProfile profile = employeeService.findProfileByUserAccountId(userAccountId)
+                .orElseThrow(() -> new EmployeeNotFoundRuntimeException(
+                        "There is no Employee profile for userAccountId: " + userAccountId));
+        return ResponseEntity.ok(profile);
+    }
+
+    @GetMapping(path = "/admin-profile")
+    public ResponseEntity<AdminProfile> findAdminProfile(@RequestParam("userAccountId") Long userAccountId) {
+        UserAccount userAccount = userAccountService.findById(userAccountId)
+                .orElseThrow(() -> new UserAccountNotFoundRuntimeException(
+                        "There is no User Account with provided id: " + userAccountId));
+        AdminProfile profile = new AdminProfile(
+                userAccount.getId(),
+                userAccount.getLogin(),
+                userAccount.getRole().name(),
+                userAccount.getCreateDate());
+        return ResponseEntity.ok(profile);
     }
 }

--- a/src/main/java/com/alex/dto/AdminProfile.java
+++ b/src/main/java/com/alex/dto/AdminProfile.java
@@ -1,0 +1,34 @@
+package com.alex.dto;
+
+import java.time.LocalDateTime;
+
+public class AdminProfile {
+
+    private Long userAccountId;
+    private String login;
+    private String role;
+    private LocalDateTime accountCreateDate;
+
+    public AdminProfile(Long userAccountId, String login, String role, LocalDateTime accountCreateDate) {
+        this.userAccountId = userAccountId;
+        this.login = login;
+        this.role = role;
+        this.accountCreateDate = accountCreateDate;
+    }
+
+    public Long getUserAccountId() {
+        return userAccountId;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public LocalDateTime getAccountCreateDate() {
+        return accountCreateDate;
+    }
+}

--- a/src/main/java/com/alex/dto/EmployeeProfile.java
+++ b/src/main/java/com/alex/dto/EmployeeProfile.java
@@ -1,0 +1,66 @@
+package com.alex.dto;
+
+import java.time.LocalDateTime;
+
+public class EmployeeProfile {
+
+    private Long employeeId;
+    private String firstName;
+    private String lastName;
+    private LocalDateTime employeeCreateDate;
+    private LocalDateTime employeeModifyDate;
+    private Long userAccountId;
+    private String login;
+    private String role;
+    private LocalDateTime accountCreateDate;
+
+    public EmployeeProfile(Long employeeId, String firstName, String lastName, LocalDateTime employeeCreateDate,
+                           LocalDateTime employeeModifyDate, Long userAccountId, String login, String role,
+                           LocalDateTime accountCreateDate) {
+        this.employeeId = employeeId;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.employeeCreateDate = employeeCreateDate;
+        this.employeeModifyDate = employeeModifyDate;
+        this.userAccountId = userAccountId;
+        this.login = login;
+        this.role = role;
+        this.accountCreateDate = accountCreateDate;
+    }
+
+    public Long getEmployeeId() {
+        return employeeId;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public LocalDateTime getEmployeeCreateDate() {
+        return employeeCreateDate;
+    }
+
+    public LocalDateTime getEmployeeModifyDate() {
+        return employeeModifyDate;
+    }
+
+    public Long getUserAccountId() {
+        return userAccountId;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public LocalDateTime getAccountCreateDate() {
+        return accountCreateDate;
+    }
+}

--- a/src/main/java/com/alex/repository/EmployeeRepository.java
+++ b/src/main/java/com/alex/repository/EmployeeRepository.java
@@ -1,6 +1,8 @@
 package com.alex.repository;
 
 import com.alex.dto.Employee;
+import com.alex.dto.EmployeeProfile;
+import com.alex.repository.mapper.EmployeeProfileRowMapper;
 import com.alex.repository.mapper.EmployeeRowMapper;
 import com.alex.exception.DataAccessRuntimeException;
 import com.alex.exception.EmployeeNotFoundRuntimeException;
@@ -105,6 +107,34 @@ public class EmployeeRepository implements IEmployeeRepository {
             if(rowAffected == 0) {
                 throw new EmployeeNotFoundRuntimeException("There is no Employee with provided id = " + id);
             }
+        } catch (DataAccessException e) {
+            throw new DataAccessRuntimeException("Can't access database: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public Optional<EmployeeProfile> findProfileByUserAccountId(Long userAccountId) {
+        String query = """
+                SELECT e.id            AS employee_id,
+                       e.first_name,
+                       e.last_name,
+                       e.create_date   AS employee_create_date,
+                       e.modify_date   AS employee_modify_date,
+                       ua.id           AS user_account_id,
+                       ua.login,
+                       ua.role,
+                       ua.create_date  AS account_create_date
+                FROM employee e
+                JOIN user_account_employee uae ON uae.employee_id = e.id
+                JOIN user_account ua ON ua.id = uae.user_account_id
+                WHERE ua.id = ?
+                  AND e.delete_date IS NULL
+                  AND ua.delete_date IS NULL
+                  AND uae.delete_date IS NULL
+                """;
+        try {
+            List<EmployeeProfile> results = jdbcTemplate.query(query, new EmployeeProfileRowMapper(), userAccountId);
+            return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
         } catch (DataAccessException e) {
             throw new DataAccessRuntimeException("Can't access database: " + e.getMessage());
         }

--- a/src/main/java/com/alex/repository/IEmployeeRepository.java
+++ b/src/main/java/com/alex/repository/IEmployeeRepository.java
@@ -1,6 +1,7 @@
 package com.alex.repository;
 
 import com.alex.dto.Employee;
+import com.alex.dto.EmployeeProfile;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +13,5 @@ public interface IEmployeeRepository {
     List<Employee> findAll();
     void updateById(Long id, Employee employee);
     void deleteById(Long id);
+    Optional<EmployeeProfile> findProfileByUserAccountId(Long userAccountId);
 }

--- a/src/main/java/com/alex/repository/mapper/EmployeeProfileRowMapper.java
+++ b/src/main/java/com/alex/repository/mapper/EmployeeProfileRowMapper.java
@@ -1,0 +1,32 @@
+package com.alex.repository.mapper;
+
+import com.alex.dto.EmployeeProfile;
+import com.alex.exception.SQLRuntimeException;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+public class EmployeeProfileRowMapper implements RowMapper<EmployeeProfile> {
+
+    @Override
+    public EmployeeProfile mapRow(ResultSet rs, int rowNum) {
+        try {
+            Timestamp employeeModifyDate = rs.getTimestamp("employee_modify_date");
+            return new EmployeeProfile(
+                    rs.getLong("employee_id"),
+                    rs.getString("first_name"),
+                    rs.getString("last_name"),
+                    rs.getTimestamp("employee_create_date").toLocalDateTime(),
+                    employeeModifyDate != null ? employeeModifyDate.toLocalDateTime() : null,
+                    rs.getLong("user_account_id"),
+                    rs.getString("login"),
+                    rs.getString("role"),
+                    rs.getTimestamp("account_create_date").toLocalDateTime()
+            );
+        } catch (SQLException e) {
+            throw new SQLRuntimeException("Database exception." + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/alex/service/EmployeeService.java
+++ b/src/main/java/com/alex/service/EmployeeService.java
@@ -2,6 +2,7 @@ package com.alex.service;
 
 import com.alex.UserAccountRole;
 import com.alex.dto.Employee;
+import com.alex.dto.EmployeeProfile;
 import com.alex.dto.Password;
 import com.alex.dto.UserAccount;
 import com.alex.exception.UserAccountNotFoundRuntimeException;
@@ -92,5 +93,12 @@ public class EmployeeService implements IEmployeeService{
                 .orElseThrow(() -> new UserAccountNotFoundRuntimeException("There is no Employee with provided id:" + employeeId));
 
         userAccountService.updatePassword(userAccountId, password);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Optional<EmployeeProfile> findProfileByUserAccountId(Long userAccountId) {
+        IdValidation.ensureIdPresent(userAccountId);
+        return employeeRepository.findProfileByUserAccountId(userAccountId);
     }
 }

--- a/src/main/java/com/alex/service/IEmployeeService.java
+++ b/src/main/java/com/alex/service/IEmployeeService.java
@@ -1,6 +1,7 @@
 package com.alex.service;
 
 import com.alex.dto.Employee;
+import com.alex.dto.EmployeeProfile;
 import com.alex.dto.Password;
 
 import java.util.List;
@@ -13,4 +14,5 @@ public interface IEmployeeService {
     List<Employee> findAll();
     void deleteById(Long id);
     void updatePassword(Long employeeId, Password password);
+    Optional<EmployeeProfile> findProfileByUserAccountId(Long userAccountId);
 }

--- a/src/main/resources/static/js/user-profile.js
+++ b/src/main/resources/static/js/user-profile.js
@@ -2,22 +2,12 @@
  * SimplyBank — User Profile Page Controller
  *
  * Loads user profile data and renders role-appropriate fields.
- * - If URL has ?id=X, calls GET /api/user_account/{id}/profile
+ * - If URL has ?id=X, fetches the user account to determine role,
+ *   then calls the appropriate profile endpoint:
+ *     CLIENT   → GET /api/client/profile?userAccountId=X
+ *     EMPLOYEE → GET /api/employee/profile?userAccountId=X
+ *     ADMIN    → GET /api/employee/admin-profile?userAccountId=X
  * - Otherwise, calls GET /api/auth/me
- *
- * Expected API response shape:
- * {
- *   "userAccountId": 1,
- *   "login": "jdoe",
- *   "role": "CLIENT",
- *   "createDate": "2024-01-15T10:30:00",
- *   "firstName": "John",
- *   "lastName": "Doe",
- *   "city": "Dublin",           // CLIENT only
- *   "street": "O'Connell",      // CLIENT only
- *   "houseNumber": "42",        // CLIENT only
- *   "identificationNumber": "IE123456789"  // CLIENT only
- * }
  *
  * Shared utilities (ajax, formatDate, escapeHtml, etc.) are in common.js.
  */
@@ -27,8 +17,11 @@
 // ============================================================
 
 var ProfileAPI = {
-    PROFILE: "/api/user_account/{id}/profile",
-    AUTH_ME: "/api/auth/me"
+    USER_ACCOUNT:    "/api/user_account/{id}",
+    CLIENT_PROFILE:  "/api/client/profile?userAccountId={id}",
+    EMPLOYEE_PROFILE: "/api/employee/profile?userAccountId={id}",
+    ADMIN_PROFILE:   "/api/employee/admin-profile?userAccountId={id}",
+    AUTH_ME:         "/api/auth/me"
 };
 
 // ============================================================
@@ -43,7 +36,7 @@ function getQueryParam(name) {
 function init() {
     var userId = getQueryParam("id");
     if (userId) {
-        loadProfile(ProfileAPI.PROFILE.replace("{id}", userId));
+        loadProfileByUserAccountId(userId);
     } else {
         loadProfile(ProfileAPI.AUTH_ME);
     }
@@ -52,6 +45,40 @@ function init() {
 // ============================================================
 // DATA LOADING
 // ============================================================
+
+function loadProfileByUserAccountId(userAccountId) {
+    showLoading(true);
+
+    var userAccountUrl = ProfileAPI.USER_ACCOUNT.replace("{id}", userAccountId);
+    ajax(userAccountUrl, "GET")
+        .done(function (userAccount) {
+            var role = (userAccount.role || "").toUpperCase();
+            var profileUrl;
+
+            if (role === "CLIENT") {
+                profileUrl = ProfileAPI.CLIENT_PROFILE.replace("{id}", userAccountId);
+            } else if (role === "EMPLOYEE") {
+                profileUrl = ProfileAPI.EMPLOYEE_PROFILE.replace("{id}", userAccountId);
+            } else if (role === "ADMIN") {
+                profileUrl = ProfileAPI.ADMIN_PROFILE.replace("{id}", userAccountId);
+            } else {
+                showLoading(false);
+                showError("Unknown role: " + role);
+                return;
+            }
+
+            loadProfile(profileUrl);
+        })
+        .fail(function (jqxhr) {
+            showLoading(false);
+            initProfileLinks();
+            var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
+                ? jqxhr.responseJSON.message
+                : "Failed to load user account";
+            showError(msg);
+            notify(msg, "error");
+        });
+}
 
 function loadProfile(url) {
     showLoading(true);
@@ -115,14 +142,19 @@ function renderPersonalInfo(profile) {
     var $fields = $("#personalInfoFields");
     $fields.empty();
 
-    appendField($fields, "First Name", escapeHtml(profile.firstName || "N/A"));
-    appendField($fields, "Last Name",  escapeHtml(profile.lastName || "N/A"));
-
     if (profile.role === "CLIENT") {
-        appendField($fields, "City",                  escapeHtml(profile.city || "N/A"));
-        appendField($fields, "Street",                escapeHtml(profile.street || "N/A"));
-        appendField($fields, "House Number",          escapeHtml(profile.houseNumber || "N/A"));
-        appendField($fields, "Identification Number", escapeHtml(profile.identificationNumber || "N/A"));
+        appendField($fields, "First Name",             escapeHtml(profile.firstName || "N/A"));
+        appendField($fields, "Last Name",              escapeHtml(profile.lastName || "N/A"));
+        appendField($fields, "City",                   escapeHtml(profile.city || "N/A"));
+        appendField($fields, "Street",                 escapeHtml(profile.street || "N/A"));
+        appendField($fields, "House Number",           escapeHtml(profile.houseNumber || "N/A"));
+        appendField($fields, "Identification Number",  escapeHtml(profile.identificationNumber || "N/A"));
+    } else if (profile.role === "EMPLOYEE") {
+        appendField($fields, "First Name", escapeHtml(profile.firstName || "N/A"));
+        appendField($fields, "Last Name",  escapeHtml(profile.lastName || "N/A"));
+    } else if (profile.role === "ADMIN") {
+        appendField($fields, "First Name", escapeHtml(profile.firstName || "N/A"));
+        appendField($fields, "Last Name",  escapeHtml(profile.lastName || "N/A"));
     }
 }
 


### PR DESCRIPTION
- Create EmployeeProfile DTO and EmployeeProfileRowMapper following the existing ClientProfile pattern
- Create AdminProfile DTO for admin users (login, role, accountCreateDate)
- Add findProfileByUserAccountId to Employee repository/service layer with JOIN query across employee, user_account_employee, user_account
- Add GET /api/employee/profile and GET /api/employee/admin-profile endpoints in EmployeeController
- Update user-profile.js to determine user role first, then call the appropriate profile endpoint (client/employee/admin)
- Add explicit EMPLOYEE and ADMIN rendering blocks in renderPersonalInfo

https://claude.ai/code/session_01EkP14cfym3xQ4BCaPFN8rG