### PR TITLE
Add JUnit test suites for unit and integration tests

### DIFF
--- a/src/test/java/com/alex/IntegrationTestSuite.java
+++ b/src/test/java/com/alex/IntegrationTestSuite.java
@@ -1,0 +1,13 @@
+package com.alex;
+
+import org.junit.platform.suite.api.IncludeClassNamePatterns;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SuiteDisplayName("SimplyBank — Integration Tests")
+@SelectPackages("com.alex")
+@IncludeClassNamePatterns(".*IntegrationTest")
+public class IntegrationTestSuite {
+}

--- a/src/test/java/com/alex/UnitTestSuite.java
+++ b/src/test/java/com/alex/UnitTestSuite.java
@@ -1,0 +1,15 @@
+package com.alex;
+
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.IncludeClassNamePatterns;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SuiteDisplayName("SimplyBank — Unit Tests")
+@SelectPackages("com.alex")
+@IncludeClassNamePatterns(".*Test")
+@ExcludeClassNamePatterns(".*IntegrationTest")
+public class UnitTestSuite {
+}


### PR DESCRIPTION
## Summary
This change introduces JUnit Platform test suites to organize and separate unit tests from integration tests, enabling more granular test execution control.

## Key Changes
- **UnitTestSuite**: New test suite that runs all tests matching the `*Test` pattern while excluding integration tests (`*IntegrationTest`)
- **IntegrationTestSuite**: New test suite that runs only tests matching the `*IntegrationTest` pattern
- Both suites target the `com.alex` package and include descriptive display names for clarity in test reports

## Implementation Details
- Uses JUnit Platform's `@Suite` annotation with declarative filtering
- Leverages `@IncludeClassNamePatterns` and `@ExcludeClassNamePatterns` for precise test selection
- Allows developers to run unit tests and integration tests independently via separate test suite execution

https://claude.ai/code/session_011viwnpTB9YCyZpjK1ecUH4