### PR TITLE
Extract crypto configuration to separate CryptoConfig class

### DIFF
--- a/src/main/java/com/alex/config/CryptoConfig.java
+++ b/src/main/java/com/alex/config/CryptoConfig.java
@@ -1,0 +1,22 @@
+package com.alex.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.security.SecureRandom;
+
+@Configuration
+public class CryptoConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecureRandom secureRandom() {
+        return new SecureRandom();
+    }
+}

--- a/src/main/java/com/alex/config/SecurityConfig.java
+++ b/src/main/java/com/alex/config/SecurityConfig.java
@@ -8,12 +8,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
-import java.security.SecureRandom;
 
 @Configuration
 @EnableWebSecurity
@@ -98,15 +94,5 @@ public class SecurityConfig {
         } catch (Exception e) {
             throw new SecurityRuntimeException("Failed to build security filter chain", e);
         }
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
-    @Bean
-    public SecureRandom secureRandom() {
-        return new SecureRandom();
     }
 }


### PR DESCRIPTION
## Summary
Refactored cryptographic bean definitions out of `SecurityConfig` into a dedicated `CryptoConfig` configuration class to improve separation of concerns and code organization.

## Key Changes
- Created new `CryptoConfig` class to centralize cryptography-related bean definitions
- Moved `PasswordEncoder` bean (BCryptPasswordEncoder) from `SecurityConfig` to `CryptoConfig`
- Moved `SecureRandom` bean from `SecurityConfig` to `CryptoConfig`
- Removed unused imports from `SecurityConfig` (BCryptPasswordEncoder, PasswordEncoder, SecureRandom)

## Implementation Details
The `CryptoConfig` class is annotated with `@Configuration` and defines two beans:
- `passwordEncoder()`: Returns a BCryptPasswordEncoder instance for password hashing
- `secureRandom()`: Returns a SecureRandom instance for cryptographic operations

This change maintains the same functionality while improving code maintainability by grouping related cryptographic configurations together, making the codebase easier to navigate and test.

https://claude.ai/code/session_01EeywyEmck9U5372UcCkaTe