### PR TITLE
Fix UserAccount role persistence by converting enum to string

### DIFF
--- a/src/main/java/com/alex/repository/UserAccountRepository.java
+++ b/src/main/java/com/alex/repository/UserAccountRepository.java
@@ -31,7 +31,7 @@ public class UserAccountRepository implements IUserAccountRepository{
                 VALUES(?, ?, ?, ?)
                 """;
         try {
-            jdbcTemplate.update(query, userAccount.getLogin(), userAccount.getPassword(), userAccount.getRole(), userAccount.getCreateDate());
+            jdbcTemplate.update(query, userAccount.getLogin(), userAccount.getPassword(), userAccount.getRole().name(), userAccount.getCreateDate());
         } catch (DataAccessException e) {
             throw new DataAccessRuntimeException("Can't access database. " + e.getMessage());
         }


### PR DESCRIPTION
## Summary
Fixed a bug in the UserAccount repository where the role enum was being persisted directly to the database instead of being converted to its string representation.

## Key Changes
- Modified `UserAccountRepository.save()` to call `.name()` on the role enum before passing it to the JDBC update query
- This ensures the role is stored as a string value in the database rather than attempting to persist the enum object itself

## Implementation Details
The change converts `userAccount.getRole()` to `userAccount.getRole().name()` in the parameterized query, allowing proper serialization of the enum value to the database. This is necessary because JDBC expects primitive/string types rather than Java enum objects when binding query parameters.

https://claude.ai/code/session_0152fhXzz1jAH7u8N13C7ins