### PR TITLE
Add admin password reset and display credentials on user creation

### DIFF
--- a/src/main/java/com/alex/config/SecurityConfig.java
+++ b/src/main/java/com/alex/config/SecurityConfig.java
@@ -70,8 +70,9 @@ public class SecurityConfig {
                             .requestMatchers(HttpMethod.GET, "/api/transaction").hasAnyRole("EMPLOYEE", "ADMIN")
                             .requestMatchers(HttpMethod.POST, "/api/transaction/**").authenticated()
 
-                            // User Account API — list all is admin-only, rest authenticated
+                            // User Account API — list all and admin password reset are admin-only, rest authenticated
                             .requestMatchers(HttpMethod.GET, "/api/user_account").hasRole("ADMIN")
+                            .requestMatchers(HttpMethod.POST, "/api/user_account/*/password/reset").hasRole("ADMIN")
                             .requestMatchers("/api/user_account/**").authenticated()
 
                             // All other pages — authenticated

--- a/src/main/java/com/alex/controller/ClientController.java
+++ b/src/main/java/com/alex/controller/ClientController.java
@@ -1,6 +1,7 @@
 package com.alex.controller;
 
 import com.alex.dto.Client;
+import com.alex.dto.ClientCreationResponse;
 import com.alex.dto.ClientProfile;
 import com.alex.exception.ClientNotFoundRuntimeException;
 import com.alex.service.IClientService;
@@ -21,9 +22,9 @@ public class ClientController {
     }
 
     @PostMapping(consumes = "application/json")
-    public ResponseEntity<Client> saveClient(@RequestBody Client client) {
-        Client clientResult = clientService.save(client);
-        return ResponseEntity.status(HttpStatus.CREATED).body(clientResult);
+    public ResponseEntity<ClientCreationResponse> saveClient(@RequestBody Client client) {
+        ClientCreationResponse response = clientService.save(client);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping(path = "/{id}", consumes = "application/json")

--- a/src/main/java/com/alex/controller/EmployeeController.java
+++ b/src/main/java/com/alex/controller/EmployeeController.java
@@ -2,6 +2,7 @@ package com.alex.controller;
 
 import com.alex.dto.AdminProfile;
 import com.alex.dto.Employee;
+import com.alex.dto.EmployeeCreationResponse;
 import com.alex.dto.EmployeeProfile;
 import com.alex.dto.UserAccount;
 import com.alex.exception.EmployeeNotFoundRuntimeException;
@@ -27,9 +28,9 @@ public class EmployeeController {
     }
 
     @PostMapping(consumes = "application/json")
-    public ResponseEntity<Employee> saveEmployee(@RequestBody Employee employee) {
-        Employee employeeResult = employeeService.save(employee);
-        return ResponseEntity.status(HttpStatus.CREATED).body(employeeResult);
+    public ResponseEntity<EmployeeCreationResponse> saveEmployee(@RequestBody Employee employee) {
+        EmployeeCreationResponse response = employeeService.save(employee);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping(path = "/{id}", consumes = "application/json")

--- a/src/main/java/com/alex/controller/UserAccountController.java
+++ b/src/main/java/com/alex/controller/UserAccountController.java
@@ -1,6 +1,7 @@
 package com.alex.controller;
 
 import com.alex.dto.Password;
+import com.alex.dto.PasswordResetResponse;
 import com.alex.dto.UserAccount;
 import com.alex.exception.AccessDeniedRuntimeException;
 import com.alex.exception.UserAccountNotFoundRuntimeException;
@@ -55,5 +56,12 @@ public class UserAccountController {
 
         userAccountService.updatePassword(id, password);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping(path = "/{id}/password/reset")
+    public ResponseEntity<PasswordResetResponse> resetPassword(@PathVariable("id") Long id) {
+        // Security: restricted to ADMIN via SecurityConfig
+        PasswordResetResponse response = userAccountService.resetPassword(id);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/alex/dto/ClientCreationResponse.java
+++ b/src/main/java/com/alex/dto/ClientCreationResponse.java
@@ -1,0 +1,26 @@
+package com.alex.dto;
+
+public class ClientCreationResponse {
+
+    private final Client client;
+    private final String login;
+    private final String generatedPassword;
+
+    public ClientCreationResponse(Client client, String login, String generatedPassword) {
+        this.client = client;
+        this.login = login;
+        this.generatedPassword = generatedPassword;
+    }
+
+    public Client getClient() {
+        return client;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public String getGeneratedPassword() {
+        return generatedPassword;
+    }
+}

--- a/src/main/java/com/alex/dto/EmployeeCreationResponse.java
+++ b/src/main/java/com/alex/dto/EmployeeCreationResponse.java
@@ -1,0 +1,26 @@
+package com.alex.dto;
+
+public class EmployeeCreationResponse {
+
+    private final Employee employee;
+    private final String login;
+    private final String generatedPassword;
+
+    public EmployeeCreationResponse(Employee employee, String login, String generatedPassword) {
+        this.employee = employee;
+        this.login = login;
+        this.generatedPassword = generatedPassword;
+    }
+
+    public Employee getEmployee() {
+        return employee;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public String getGeneratedPassword() {
+        return generatedPassword;
+    }
+}

--- a/src/main/java/com/alex/dto/PasswordResetResponse.java
+++ b/src/main/java/com/alex/dto/PasswordResetResponse.java
@@ -1,0 +1,26 @@
+package com.alex.dto;
+
+public class PasswordResetResponse {
+
+    private final Long userAccountId;
+    private final String login;
+    private final String newPassword;
+
+    public PasswordResetResponse(Long userAccountId, String login, String newPassword) {
+        this.userAccountId = userAccountId;
+        this.login = login;
+        this.newPassword = newPassword;
+    }
+
+    public Long getUserAccountId() {
+        return userAccountId;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+}

--- a/src/main/java/com/alex/service/ClientService.java
+++ b/src/main/java/com/alex/service/ClientService.java
@@ -2,6 +2,7 @@ package com.alex.service;
 
 import com.alex.UserAccountRole;
 import com.alex.dto.Client;
+import com.alex.dto.ClientCreationResponse;
 import com.alex.dto.ClientProfile;
 import com.alex.dto.UserAccount;
 import com.alex.exception.UserAccountNotFoundRuntimeException;
@@ -38,7 +39,7 @@ public class ClientService implements IClientService {
 
     @Transactional
     @Override
-    public Client save(Client client) {
+    public ClientCreationResponse save(Client client) {
         ClientValidation.ensureClientPresent(client);
         UserAccountValidation.ensureFirstNamePresent(client.getFirstName());
         UserAccountValidation.ensureLastNamePresent(client.getLastName());
@@ -52,7 +53,7 @@ public class ClientService implements IClientService {
         UserAccount userAccount = userAccountService.save(client.getFirstName(), client.getLastName(),
                 UserAccountRole.CLIENT);
         userAccountClientRepository.linkUserAccountToClient(userAccount.getId(), id);
-        return savedClient;
+        return new ClientCreationResponse(savedClient, userAccount.getLogin(), userAccount.getPassword());
     }
 
     @Transactional

--- a/src/main/java/com/alex/service/EmployeeService.java
+++ b/src/main/java/com/alex/service/EmployeeService.java
@@ -2,6 +2,7 @@ package com.alex.service;
 
 import com.alex.UserAccountRole;
 import com.alex.dto.Employee;
+import com.alex.dto.EmployeeCreationResponse;
 import com.alex.dto.EmployeeProfile;
 import com.alex.dto.UserAccount;
 import com.alex.exception.UserAccountNotFoundRuntimeException;
@@ -32,7 +33,7 @@ public class EmployeeService implements IEmployeeService{
 
     @Transactional
     @Override
-    public Employee save(Employee employee) {
+    public EmployeeCreationResponse save(Employee employee) {
         EmployeeValidation.ensureEmployeePresent(employee);
         UserAccountValidation.ensureFirstNamePresent(employee.getFirstName());
         UserAccountValidation.ensureLastNamePresent(employee.getLastName());
@@ -45,7 +46,7 @@ public class EmployeeService implements IEmployeeService{
         UserAccount userAccount = userAccountService.save(employee.getFirstName(), employee.getLastName(),
                 UserAccountRole.EMPLOYEE);
         userAccountEmployeeRepository.linkUserAccountToEmployee(userAccount.getId(), id);
-        return savedEmployee;
+        return new EmployeeCreationResponse(savedEmployee, userAccount.getLogin(), userAccount.getPassword());
     }
 
     @Transactional

--- a/src/main/java/com/alex/service/IClientService.java
+++ b/src/main/java/com/alex/service/IClientService.java
@@ -1,13 +1,14 @@
 package com.alex.service;
 
 import com.alex.dto.Client;
+import com.alex.dto.ClientCreationResponse;
 import com.alex.dto.ClientProfile;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface IClientService {
-    Client save(Client client);
+    ClientCreationResponse save(Client client);
     void updateById(Long id, Client client);
     Optional<Client> findById(Long id);
     List<Client> findAll();

--- a/src/main/java/com/alex/service/IEmployeeService.java
+++ b/src/main/java/com/alex/service/IEmployeeService.java
@@ -1,13 +1,14 @@
 package com.alex.service;
 
 import com.alex.dto.Employee;
+import com.alex.dto.EmployeeCreationResponse;
 import com.alex.dto.EmployeeProfile;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface IEmployeeService {
-    Employee save(Employee employee);
+    EmployeeCreationResponse save(Employee employee);
     void updateById(Long id, Employee employee);
     Optional<Employee> findById(Long id);
     List<Employee> findAll();

--- a/src/main/java/com/alex/service/IUserAccountService.java
+++ b/src/main/java/com/alex/service/IUserAccountService.java
@@ -2,6 +2,7 @@ package com.alex.service;
 
 import com.alex.UserAccountRole;
 import com.alex.dto.Password;
+import com.alex.dto.PasswordResetResponse;
 import com.alex.dto.UserAccount;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
@@ -11,6 +12,7 @@ import java.util.Optional;
 public interface IUserAccountService extends UserDetailsService {
     UserAccount save(String firstName, String lastName, UserAccountRole role);
     void updatePassword(Long userAccountId, Password password);
+    PasswordResetResponse resetPassword(Long userAccountId);
     Optional<UserAccount> findById(Long id);
     List<UserAccount> findAll();
     void deleteById(Long id);

--- a/src/main/java/com/alex/service/UserAccountService.java
+++ b/src/main/java/com/alex/service/UserAccountService.java
@@ -2,6 +2,7 @@ package com.alex.service;
 
 import com.alex.UserAccountRole;
 import com.alex.dto.Password;
+import com.alex.dto.PasswordResetResponse;
 import com.alex.dto.UserAccount;
 import com.alex.exception.UserAccountNotFoundRuntimeException;
 import com.alex.repository.IUserAccountRepository;
@@ -69,6 +70,21 @@ public class UserAccountService implements IUserAccountService{
 
         String encodedNewPassword = passwordEncoder.encode(password.getNewPassword());
         userAccountRepository.updatePassword(userAccountId, encodedNewPassword);
+    }
+
+    @Transactional
+    @Override
+    public PasswordResetResponse resetPassword(Long userAccountId) {
+        IdValidation.ensureIdPresent(userAccountId);
+
+        UserAccount userAccount = userAccountRepository.findById(userAccountId)
+                .orElseThrow(() -> new UserAccountNotFoundRuntimeException(
+                        "There is no User Account with provided id:" + userAccountId));
+
+        String newPassword = userAccountProcessingService.generatePassword();
+        userAccountRepository.updatePassword(userAccountId, passwordEncoder.encode(newPassword));
+
+        return new PasswordResetResponse(userAccountId, userAccount.getLogin(), newPassword);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/static/css/management.css
+++ b/src/main/resources/static/css/management.css
@@ -596,6 +596,49 @@ select.field-input {
 }
 
 /* ============================================================
+   Credential Modal
+   ============================================================ */
+.credential-warning {
+    background: #fef3c7;
+    border: 1px solid #fcd34d;
+    color: #92400e;
+    padding: 12px 14px;
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+    margin-bottom: 18px;
+}
+.credential-row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 14px;
+    background: var(--gray-50);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-sm);
+    margin-bottom: 10px;
+}
+.credential-row:last-child {
+    margin-bottom: 0;
+}
+.credential-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--gray-400);
+    width: 80px;
+    flex-shrink: 0;
+}
+.credential-value {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--gray-900);
+    word-break: break-all;
+    user-select: all;
+}
+
+/* ============================================================
    Notification Toast
    ============================================================ */
 .notification {

--- a/src/main/resources/static/js/management.js
+++ b/src/main/resources/static/js/management.js
@@ -15,8 +15,42 @@ var ManagementAPI = {
     EMPLOYEE:         "/api/employee",
     EMPLOYEE_PROFILE: "/api/employee/profile",
     BANK_ACCOUNT:     "/api/bank_account",
+    USER_ACCOUNT:     "/api/user_account",
     AUTH_ME:          "/api/auth/me"
 };
+
+// ============================================================
+// CREDENTIAL MODAL (new user credentials, password resets)
+// ============================================================
+
+function showCredentialsModal(title, description, login, password) {
+    $("#credentialModalTitle").text(title);
+    $("#credentialModalDescription").text(description);
+    $("#credentialModalLogin").text(login || "");
+    $("#credentialModalPassword").text(password || "");
+    $("#credentialModalOverlay").addClass("open");
+}
+
+function closeCredentialsModal() {
+    $("#credentialModalOverlay").removeClass("open");
+}
+
+function copyCredentials() {
+    var login = $("#credentialModalLogin").text();
+    var password = $("#credentialModalPassword").text();
+    var text = "Login: " + login + "\nPassword: " + password;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text)
+            .then(function () { notify("Credentials copied", "success"); })
+            .catch(function () { notify("Copy failed", "error"); });
+    } else {
+        var $ta = $("<textarea>").val(text).css({ position: "fixed", opacity: 0 }).appendTo("body");
+        $ta[0].select();
+        try { document.execCommand("copy"); notify("Credentials copied", "success"); }
+        catch (e) { notify("Copy failed", "error"); }
+        $ta.remove();
+    }
+}
 
 // ============================================================
 // CONFIRM MODAL
@@ -96,11 +130,19 @@ function submitClient() {
     $("#btnAddClient").prop("disabled", true).html("Adding\u2026");
 
     ajax(ManagementAPI.CLIENT, "POST", data)
-        .done(function () {
+        .done(function (response) {
             notify("Client added successfully", "success");
             $("#clientForm")[0].reset();
             $(".field-input", "#clientForm").removeClass("invalid");
             $(".field-error", "#clientForm").text("");
+            if (response && response.login) {
+                showCredentialsModal(
+                    "Client Created",
+                    "Copy these credentials now \u2014 they will not be shown again.",
+                    response.login,
+                    response.generatedPassword
+                );
+            }
         })
         .fail(function (jqxhr) {
             var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
@@ -397,11 +439,19 @@ function submitEmployee() {
     $("#btnAddEmployee").prop("disabled", true).html("Adding\u2026");
 
     ajax(ManagementAPI.EMPLOYEE, "POST", data)
-        .done(function () {
+        .done(function (response) {
             notify("Employee added successfully", "success");
             $("#employeeForm")[0].reset();
             $(".field-input", "#employeeForm").removeClass("invalid");
             $(".field-error", "#employeeForm").text("");
+            if (response && response.login) {
+                showCredentialsModal(
+                    "Employee Created",
+                    "Copy these credentials now \u2014 they will not be shown again.",
+                    response.login,
+                    response.generatedPassword
+                );
+            }
         })
         .fail(function (jqxhr) {
             var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
@@ -645,6 +695,67 @@ function deleteEmployee() {
 }
 
 // ============================================================
+// PASSWORD RESET (admin-only)
+// ============================================================
+
+function resetPasswordFor(inputId, errorId, buttonId, defaultButtonHtml, entityLabel) {
+    var accountId = $.trim($("#" + inputId).val());
+    $("#" + errorId).text("");
+    $("#" + inputId).removeClass("invalid");
+
+    if (!accountId) {
+        $("#" + errorId).text("User Account ID is required");
+        $("#" + inputId).addClass("invalid");
+        return;
+    }
+
+    confirmAction(
+        "Reset " + entityLabel + " Password",
+        "Generate a new password for user account #" + accountId + "? The current password will stop working immediately.",
+        function () {
+            $("#" + buttonId).prop("disabled", true).html("Resetting\u2026");
+
+            ajax(ManagementAPI.USER_ACCOUNT + "/" + encodeURIComponent(accountId) + "/password/reset", "POST")
+                .done(function (response) {
+                    notify("Password reset successfully", "success");
+                    $("#" + inputId).val("");
+                    showCredentialsModal(
+                        entityLabel + " Password Reset",
+                        "Share the new password with the " + entityLabel.toLowerCase() + " \u2014 it will not be shown again.",
+                        response.login,
+                        response.newPassword
+                    );
+                })
+                .fail(function (jqxhr) {
+                    var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
+                        ? jqxhr.responseJSON.message
+                        : "Failed to reset password";
+                    notify(msg, "error");
+                })
+                .always(function () {
+                    $("#" + buttonId).prop("disabled", false).html(defaultButtonHtml);
+                });
+        }
+    );
+}
+
+var RESET_BUTTON_HTML =
+    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
+        '<polyline points="23 4 23 10 17 10"/>' +
+        '<path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>' +
+    '</svg> Reset Password';
+
+function resetClientPassword() {
+    resetPasswordFor("resetClientAccountId", "resetClientAccountIdError",
+        "btnResetClientPassword", RESET_BUTTON_HTML, "Client");
+}
+
+function resetEmployeePassword() {
+    resetPasswordFor("resetEmpAccountId", "resetEmpAccountIdError",
+        "btnResetEmpPassword", RESET_BUTTON_HTML, "Employee");
+}
+
+// ============================================================
 // BANK ACCOUNT: Create
 // ============================================================
 
@@ -805,6 +916,10 @@ $(document).ready(function () {
     });
     $("#btnDeleteEmployee").on("click", deleteEmployee);
 
+    // --- Password Reset ---
+    $("#btnResetClientPassword").on("click", resetClientPassword);
+    $("#btnResetEmpPassword").on("click", resetEmployeePassword);
+
     // --- Bank Account ---
     $("#createBankAccountForm").on("submit", function (e) {
         e.preventDefault();
@@ -825,9 +940,18 @@ $(document).ready(function () {
     $("#confirmModalOverlay").on("click", function (e) {
         if (e.target === this) closeConfirmModal();
     });
+
+    // --- Credential Modal ---
+    $("#credentialModalOk, #credentialModalClose").on("click", closeCredentialsModal);
+    $("#credentialModalCopy").on("click", copyCredentials);
+    $("#credentialModalOverlay").on("click", function (e) {
+        if (e.target === this) closeCredentialsModal();
+    });
+
     $(document).on("keydown", function (e) {
-        if (e.key === "Escape" && $("#confirmModalOverlay").hasClass("open")) {
-            closeConfirmModal();
+        if (e.key === "Escape") {
+            if ($("#confirmModalOverlay").hasClass("open")) closeConfirmModal();
+            if ($("#credentialModalOverlay").hasClass("open")) closeCredentialsModal();
         }
     });
 });

--- a/src/main/resources/static/js/management.js
+++ b/src/main/resources/static/js/management.js
@@ -42,12 +42,18 @@ function copyCredentials() {
     if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(text)
             .then(function () { notify("Credentials copied", "success"); })
-            .catch(function () { notify("Copy failed", "error"); });
+            .catch(function (err) {
+                console.error("[copyCredentials] navigator.clipboard.writeText failed:", err);
+                notify("Copy failed", "error");
+            });
     } else {
         var $ta = $("<textarea>").val(text).css({ position: "fixed", opacity: 0 }).appendTo("body");
         $ta[0].select();
         try { document.execCommand("copy"); notify("Credentials copied", "success"); }
-        catch (e) { notify("Copy failed", "error"); }
+        catch (e) {
+            console.error("[copyCredentials] document.execCommand('copy') fallback failed:", e);
+            notify("Copy failed", "error");
+        }
         $ta.remove();
     }
 }

--- a/src/main/resources/templates/management.html
+++ b/src/main/resources/templates/management.html
@@ -301,6 +301,36 @@
                     </div>
                 </section>
 
+                <!-- Reset Client Password -->
+                <section class="mgmt-card">
+                    <div class="mgmt-card-header">
+                        <div class="mgmt-card-icon blue">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+                                <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                            </svg>
+                        </div>
+                        <h2 class="mgmt-card-title">Reset Client Password</h2>
+                        <p class="mgmt-card-desc">Generate a new password for a client who forgot theirs</p>
+                    </div>
+                    <div class="form-grid">
+                        <div class="field-group">
+                            <label class="field-label" for="resetClientAccountId">User Account ID <span class="req">*</span></label>
+                            <input class="field-input" type="number" id="resetClientAccountId" placeholder="Enter user account ID">
+                            <div class="field-error" id="resetClientAccountIdError"></div>
+                        </div>
+                    </div>
+                    <div class="form-actions">
+                        <button class="btn btn-primary" id="btnResetClientPassword" type="button">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="23 4 23 10 17 10"/>
+                                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+                            </svg>
+                            Reset Password
+                        </button>
+                    </div>
+                </section>
+
             </div>
 
             <!-- ============================================================
@@ -494,6 +524,36 @@
                     </div>
                 </section>
 
+                <!-- Reset Employee Password -->
+                <section class="mgmt-card">
+                    <div class="mgmt-card-header">
+                        <div class="mgmt-card-icon green">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+                                <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                            </svg>
+                        </div>
+                        <h2 class="mgmt-card-title">Reset Employee Password</h2>
+                        <p class="mgmt-card-desc">Generate a new password for an employee who forgot theirs</p>
+                    </div>
+                    <div class="form-grid">
+                        <div class="field-group">
+                            <label class="field-label" for="resetEmpAccountId">User Account ID <span class="req">*</span></label>
+                            <input class="field-input" type="number" id="resetEmpAccountId" placeholder="Enter user account ID">
+                            <div class="field-error" id="resetEmpAccountIdError"></div>
+                        </div>
+                    </div>
+                    <div class="form-actions">
+                        <button class="btn btn-primary btn-green" id="btnResetEmpPassword" type="button">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="23 4 23 10 17 10"/>
+                                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+                            </svg>
+                            Reset Password
+                        </button>
+                    </div>
+                </section>
+
             </div>
 
             <!-- ============================================================
@@ -591,6 +651,37 @@
 
         </div>
     </main>
+
+    <!-- Credentials Modal (shown after creating a user or resetting a password) -->
+    <div class="modal-overlay" id="credentialModalOverlay">
+        <div class="modal credential-modal">
+            <div class="modal-header">
+                <h2 class="modal-title" id="credentialModalTitle">Generated Credentials</h2>
+                <button class="modal-close" id="credentialModalClose" type="button">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p class="credential-warning" id="credentialModalDescription">
+                    Copy these credentials now &mdash; they will not be shown again.
+                </p>
+                <div class="credential-row">
+                    <span class="credential-label">Login</span>
+                    <code class="credential-value" id="credentialModalLogin"></code>
+                </div>
+                <div class="credential-row">
+                    <span class="credential-label">Password</span>
+                    <code class="credential-value" id="credentialModalPassword"></code>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" id="credentialModalCopy" type="button">Copy</button>
+                <button class="btn btn-primary" id="credentialModalOk" type="button">Done</button>
+            </div>
+        </div>
+    </div>
 
     <!-- Confirm Delete Modal -->
     <div class="modal-overlay" id="confirmModalOverlay">

--- a/src/test/java/com/alex/controller/ClientControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/ClientControllerIntegrationTest.java
@@ -65,8 +65,10 @@ class ClientControllerIntegrationTest extends BaseIntegrationTest {
                         .contentType("application/json")
                         .content(clientJson("New", "Client")))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.firstName").value("New"))
-                .andExpect(jsonPath("$.lastName").value("Client"));
+                .andExpect(jsonPath("$.client.firstName").value("New"))
+                .andExpect(jsonPath("$.client.lastName").value("Client"))
+                .andExpect(jsonPath("$.login").isNotEmpty())
+                .andExpect(jsonPath("$.generatedPassword").isNotEmpty());
     }
 
     @Test
@@ -233,7 +235,9 @@ class ClientControllerIntegrationTest extends BaseIntegrationTest {
                         .content(saveBody))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
-        Long id = ((Number) objectMapper.readValue(response, Map.class).get("id")).longValue();
+        Map<?, ?> responseMap = objectMapper.readValue(response, Map.class);
+        Map<?, ?> clientNode = (Map<?, ?>) responseMap.get("client");
+        Long id = ((Number) clientNode.get("id")).longValue();
 
         mockMvc.perform(delete("/api/client/" + id).header("Authorization", bearer(token)))
                 .andExpect(status().isNoContent());

--- a/src/test/java/com/alex/controller/EmployeeControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/EmployeeControllerIntegrationTest.java
@@ -67,8 +67,10 @@ class EmployeeControllerIntegrationTest extends BaseIntegrationTest {
                         .contentType("application/json")
                         .content(employeeJson("Eve", "Manager")))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.firstName").value("Eve"))
-                .andExpect(jsonPath("$.lastName").value("Manager"));
+                .andExpect(jsonPath("$.employee.firstName").value("Eve"))
+                .andExpect(jsonPath("$.employee.lastName").value("Manager"))
+                .andExpect(jsonPath("$.login").isNotEmpty())
+                .andExpect(jsonPath("$.generatedPassword").isNotEmpty());
     }
 
     // PUT /api/employee/{id} ------------------------------------------------------------------
@@ -169,7 +171,9 @@ class EmployeeControllerIntegrationTest extends BaseIntegrationTest {
                         .content(employeeJson("Del", "Target")))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
-        Long id = ((Number) objectMapper.readValue(body, Map.class).get("id")).longValue();
+        Map<?, ?> responseMap = objectMapper.readValue(body, Map.class);
+        Map<?, ?> employeeNode = (Map<?, ?>) responseMap.get("employee");
+        Long id = ((Number) employeeNode.get("id")).longValue();
 
         mockMvc.perform(delete("/api/employee/" + id).header("Authorization", bearer(token)))
                 .andExpect(status().isNoContent());

--- a/src/test/java/com/alex/controller/UserAccountControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/UserAccountControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
@@ -189,5 +190,61 @@ class UserAccountControllerIntegrationTest extends BaseIntegrationTest {
                         .contentType("application/json")
                         .content(body))
                 .andExpect(status().isBadRequest()); // reached the service, password mismatch
+    }
+
+    // POST /api/user_account/{id}/password/reset (admin-only) -------------------------------
+
+    @Test
+    void resetPassword_asAdmin_returnsNewPassword() throws Exception {
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        insertUserAccount(3L, "carol", "Password1!", "ADMIN");
+        String token = generateToken("carol", "ADMIN");
+
+        mockMvc.perform(post("/api/user_account/1/password/reset")
+                        .header("Authorization", bearer(token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userAccountId").value(1))
+                .andExpect(jsonPath("$.login").value("alice"))
+                .andExpect(jsonPath("$.newPassword").isNotEmpty());
+    }
+
+    @Test
+    void resetPassword_asEmployee_isForbidden() throws Exception {
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        insertUserAccount(2L, "bob", "Password1!", "EMPLOYEE");
+        String token = generateToken("bob", "EMPLOYEE");
+
+        mockMvc.perform(post("/api/user_account/1/password/reset")
+                        .header("Authorization", bearer(token)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void resetPassword_asClient_isForbidden() throws Exception {
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        insertUserAccount(2L, "bob", "Password1!", "CLIENT");
+        String token = generateToken("bob", "CLIENT");
+
+        mockMvc.perform(post("/api/user_account/1/password/reset")
+                        .header("Authorization", bearer(token)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void resetPassword_noToken_redirectsToLogin() throws Exception {
+        mockMvc.perform(post("/api/user_account/1/password/reset"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    void resetPassword_missingUser_returnsNotFound() throws Exception {
+        insertUserAccount(3L, "carol", "Password1!", "ADMIN");
+        String token = generateToken("carol", "ADMIN");
+
+        mockMvc.perform(post("/api/user_account/999/password/reset")
+                        .header("Authorization", bearer(token)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("There is no User Account with provided id:999"));
     }
 }

--- a/src/test/java/com/alex/service/ClientServiceTest.java
+++ b/src/test/java/com/alex/service/ClientServiceTest.java
@@ -2,6 +2,7 @@ package com.alex.service;
 
 import com.alex.UserAccountRole;
 import com.alex.dto.Client;
+import com.alex.dto.ClientCreationResponse;
 import com.alex.dto.ClientProfile;
 import com.alex.dto.UserAccount;
 import com.alex.exception.IllegalArgumentRuntimeException;
@@ -70,15 +71,17 @@ class ClientServiceTest {
     }
 
     @Test
-    void save_valid_persistsClientCreatesUserAndLinks() {
+    void save_valid_persistsClientCreatesUserAndReturnsCredentials() {
         when(clientRepository.save(any(Client.class))).thenReturn(42L);
         when(userAccountService.save("Alice", "Smith", UserAccountRole.CLIENT)).thenReturn(newUser(99L));
 
-        Client result = service.save(newClient("Alice", "Smith"));
+        ClientCreationResponse result = service.save(newClient("Alice", "Smith"));
 
-        assertThat(result.getId()).isEqualTo(42L);
-        assertThat(result.getFirstName()).isEqualTo("Alice");
-        assertThat(result.getLastName()).isEqualTo("Smith");
+        assertThat(result.getClient().getId()).isEqualTo(42L);
+        assertThat(result.getClient().getFirstName()).isEqualTo("Alice");
+        assertThat(result.getClient().getLastName()).isEqualTo("Smith");
+        assertThat(result.getLogin()).isEqualTo("alismi");
+        assertThat(result.getGeneratedPassword()).isEqualTo("pwd");
 
         ArgumentCaptor<Client> captor = ArgumentCaptor.forClass(Client.class);
         verify(clientRepository).save(captor.capture());

--- a/src/test/java/com/alex/service/EmployeeServiceTest.java
+++ b/src/test/java/com/alex/service/EmployeeServiceTest.java
@@ -2,6 +2,7 @@ package com.alex.service;
 
 import com.alex.UserAccountRole;
 import com.alex.dto.Employee;
+import com.alex.dto.EmployeeCreationResponse;
 import com.alex.dto.EmployeeProfile;
 import com.alex.dto.UserAccount;
 import com.alex.exception.IllegalArgumentRuntimeException;
@@ -61,15 +62,17 @@ class EmployeeServiceTest {
     }
 
     @Test
-    void save_valid_persistsEmployeeCreatesUserAndLinks() {
+    void save_valid_persistsEmployeeCreatesUserAndReturnsCredentials() {
         when(employeeRepository.save(any(Employee.class))).thenReturn(42L);
         when(userAccountService.save("Bob", "Jones", UserAccountRole.EMPLOYEE)).thenReturn(newUser(99L));
 
-        Employee result = service.save(new Employee("Bob", "Jones", null));
+        EmployeeCreationResponse result = service.save(new Employee("Bob", "Jones", null));
 
-        assertThat(result.getId()).isEqualTo(42L);
-        assertThat(result.getFirstName()).isEqualTo("Bob");
-        assertThat(result.getLastName()).isEqualTo("Jones");
+        assertThat(result.getEmployee().getId()).isEqualTo(42L);
+        assertThat(result.getEmployee().getFirstName()).isEqualTo("Bob");
+        assertThat(result.getEmployee().getLastName()).isEqualTo("Jones");
+        assertThat(result.getLogin()).isEqualTo("bobjon");
+        assertThat(result.getGeneratedPassword()).isEqualTo("pwd");
         verify(userAccountEmployeeRepository).linkUserAccountToEmployee(99L, 42L);
     }
 

--- a/src/test/java/com/alex/service/UserAccountServiceTest.java
+++ b/src/test/java/com/alex/service/UserAccountServiceTest.java
@@ -2,6 +2,7 @@ package com.alex.service;
 
 import com.alex.UserAccountRole;
 import com.alex.dto.Password;
+import com.alex.dto.PasswordResetResponse;
 import com.alex.dto.UserAccount;
 import com.alex.exception.IllegalArgumentRuntimeException;
 import com.alex.exception.NullPointerRuntimeException;
@@ -137,6 +138,42 @@ class UserAccountServiceTest {
 
         service.updatePassword(1L, password);
 
+        verify(userAccountRepository).updatePassword(1L, "new-encoded");
+    }
+
+    // resetPassword -------------------------------------------------------------------------------
+
+    @Test
+    void resetPassword_nullId_throwsNullPointerRuntimeException() {
+        assertThatThrownBy(() -> service.resetPassword(null))
+                .isInstanceOf(NullPointerRuntimeException.class);
+        verify(userAccountRepository, never()).updatePassword(any(), any());
+    }
+
+    @Test
+    void resetPassword_userNotFound_throwsUserAccountNotFoundRuntimeException() {
+        when(userAccountRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.resetPassword(1L))
+                .isInstanceOf(UserAccountNotFoundRuntimeException.class)
+                .hasMessageContaining("There is no User Account with provided id:1");
+
+        verify(userAccountRepository, never()).updatePassword(any(), any());
+    }
+
+    @Test
+    void resetPassword_happyPath_generatesEncodesPersistsAndReturnsPlaintext() {
+        UserAccount existing = new UserAccount(1L, "alismi", "old-encoded", UserAccountRole.CLIENT,
+                LocalDateTime.now());
+        when(userAccountRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(processingService.generatePassword()).thenReturn("GenPwd-1!");
+        when(passwordEncoder.encode("GenPwd-1!")).thenReturn("new-encoded");
+
+        PasswordResetResponse response = service.resetPassword(1L);
+
+        assertThat(response.getUserAccountId()).isEqualTo(1L);
+        assertThat(response.getLogin()).isEqualTo("alismi");
+        assertThat(response.getNewPassword()).isEqualTo("GenPwd-1!");
         verify(userAccountRepository).updatePassword(1L, "new-encoded");
     }
 


### PR DESCRIPTION
## Summary
This PR adds the ability for admins to reset user passwords and displays generated credentials to admins when creating new clients or employees. A new credentials modal has been added to securely display and copy login credentials.

## Key Changes

**Backend:**
- Added `POST /api/user_account/{id}/password/reset` endpoint (admin-only) that generates a new password and returns it in a `PasswordResetResponse`
- Created three new DTO response classes:
  - `PasswordResetResponse` - contains user account ID, login, and new password
  - `ClientCreationResponse` - wraps created client with login and generated password
  - `EmployeeCreationResponse` - wraps created employee with login and generated password
- Modified `ClientService.save()` and `EmployeeService.save()` to return creation response objects instead of just the entity
- Updated `ClientController` and `EmployeeController` to return the new response types
- Added `resetPassword()` method to `UserAccountService` that generates, encodes, and persists a new password
- Updated security configuration to allow admins to POST to the password reset endpoint

**Frontend:**
- Added credentials modal component with copy-to-clipboard functionality (supports both modern Clipboard API and fallback)
- Added "Reset Client Password" and "Reset Employee Password" sections to the management UI
- Modified client and employee creation forms to display the credentials modal on successful creation
- Added `resetPasswordFor()` function that handles password reset with confirmation dialog
- Updated event handlers to support opening/closing the credentials modal and keyboard shortcuts (Escape key)

**Styling:**
- Added `.credential-warning`, `.credential-row`, `.credential-label`, and `.credential-value` CSS classes for the credentials modal

**Testing:**
- Added integration tests for the password reset endpoint covering: admin access, forbidden access for non-admins, missing authentication, and not-found scenarios
- Updated unit tests for `ClientService` and `EmployeeService` to verify the new response types
- Updated integration tests for client and employee creation to verify credentials are returned

## Implementation Details
- Generated passwords are returned in plaintext only in the response; they are encoded before storage
- The credentials modal includes a warning that credentials will not be shown again
- Copy functionality gracefully falls back to older browsers using `document.execCommand("copy")`
- Password reset requires admin role and is protected by Spring Security configuration

https://claude.ai/code/session_0152fhXzz1jAH7u8N13C7ins