### PR TITLE
Fix modal UX and delete callback bugs on management page

### DIFF
--- a/src/main/resources/claude/simplybank-changelog.md
+++ b/src/main/resources/claude/simplybank-changelog.md
@@ -6,6 +6,40 @@ Branch: `claude/organize-resources-add-tests-GBdM2`
 
 ---
 
+## Session 3 — management page modal & delete fixes (2026-04-28)
+
+**Branch:** `claude/fix-modal-outside-click-byOlg`
+
+**Goal:** Fix four UX/logic bugs on the `/management` page reported by the user.
+
+**Issues addressed:**
+
+1. Credentials modal (shown after creating a client/employee or resetting a password) was closing on outside click / ESC. It must only close via the explicit "Done" confirm button so admins don't accidentally lose unrecoverable credentials.
+2. After editing, deleting, or resetting a password, the page kept stale form values. The page now reloads after a successful mutation (immediately for edit/delete, after the credentials modal is dismissed for create / password-reset).
+3. Delete Client / Delete Employee did nothing after pressing the confirm button. Root cause: in the `#confirmModalOk` click handler, `closeConfirmModal()` was called first, and `closeConfirmModal()` itself was nulling out `pendingConfirmCallback` — so the subsequent `if (typeof pendingConfirmCallback === "function")` check was always false and the actual delete callback never ran.
+4. The Delete confirmation modal only showed the entity ID. It now also shows the first + last name fetched via the existing GET endpoint, so the admin can sanity-check before destruction.
+
+**Changed:**
+
+- `src/main/resources/static/js/management.js`
+  - `showCredentialsModal` / `closeCredentialsModal` — added a `reloadOnClose` flag; when true, `closeCredentialsModal` calls `window.location.reload()` after hiding the overlay.
+  - `closeConfirmModal` — no longer mutates `pendingConfirmCallback`. The OK / Cancel / overlay / ESC handlers now manage that state themselves.
+  - `$("#confirmModalOk")` click handler — captures the callback into a local before calling `closeConfirmModal()`, so the callback actually runs (this is the fix for "delete does nothing").
+  - `deleteClient` / `deleteEmployee` — now first GET the entity, build a confirm message including `firstName + lastName`, then run the DELETE inside the confirm callback. On success, reloads the page after a short delay so the toast remains visible.
+  - `submitEditClient` / `submitEditEmployee` / `deleteBankAccount` — reload after a successful mutation so all forms come back empty.
+  - `submitClient` / `submitEmployee` / `resetPasswordFor` — pass `reloadOnClose=true` to `showCredentialsModal` so the page reloads only after the credentials are explicitly acknowledged.
+  - Removed the credential-modal outside-click handler, ESC handler, and X close handler — leaving only the "Done" button as the dismiss path.
+- `src/main/resources/templates/management.html`
+  - Removed the X close button from the credentials modal header (the only dismiss path is now the "Done" button in the footer).
+- `src/main/resources/claude/simplybank-project-architecture.md`
+  - Added a "Static frontend (`src/main/resources/static`)" section so the JS / template structure is documented alongside the Java layout.
+- `src/main/resources/claude/simplybank-changelog.md`
+  - This entry.
+
+**Not changed:** No backend code touched. The delete endpoints (`ClientController` / `EmployeeController` / their services) were already correct; the only delete bug was in the frontend confirm-modal callback wiring.
+
+---
+
 ## Session 2 — resume test authoring (2026-04-15)
 
 **Goal:** resume the approved plan `/root/.claude/plans/staged-spinning-cascade.md` after a compaction break.

--- a/src/main/resources/claude/simplybank-project-architecture.md
+++ b/src/main/resources/claude/simplybank-project-architecture.md
@@ -128,6 +128,27 @@ All static methods. Throw `NullPointerRuntimeException` / `IllegalArgumentRuntim
 | `PasswordValidation` | length ≥ 8, has upper, lower, digit, special; `authenticate` via `PasswordEncoder`; reject reusing current password. |
 | `TransactionValidation` | description ≤ 255, amount > 0, accounts differ on transfer, balance sufficient, currencies match. |
 
+## Static frontend (`src/main/resources/static` + `templates`)
+
+Server-rendered Thymeleaf shells with vanilla jQuery on top — no build step, no SPA framework.
+
+| Template | Page JS | Purpose |
+| --- | --- | --- |
+| `login.html` | `login.js` | Form login (Spring Security). |
+| `dashboard.html` | `dashboard.js` | Landing page after login. |
+| `accounts.html` / `account.html` | `accounts.js` / `account.js` | List of bank accounts; single-account drilldown. |
+| `transactions.html` | `transactions.js` | Transaction history view. |
+| `new-transaction.html` | `new-transaction.js` | Transfer / deposit / withdraw form. |
+| `user-profile.html` | `user-profile.js` | Profile + change password. |
+| `management.html` | `management.js` | ADMIN-only CRUD console (Clients / Employees / Bank Accounts tabs + password reset). |
+
+Shared helpers live in `static/js/common.js`: `ajax(url, method, data)` (jQuery `$.ajax` wrapper, JSON in/out), `escapeHtml`, `notify(msg, level)`, `formatDate`, `formatCurrency`, `maskAccount`, `renderUserHeader`, `initProfileLinks`. jQuery is bundled at `static/js/libs/jquery-3.6.0.min.js`.
+
+Per-page CSS lives in `static/css/<page>.css`. The management page additionally defines two reusable modal patterns:
+
+- **Credentials modal** (`#credentialModalOverlay`) — shown after a successful create-client / create-employee / password-reset. Closes only via the "Done" button (no overlay-click, no ESC, no X) because credentials are shown exactly once.
+- **Confirm modal** (`#confirmModalOverlay`) — generic confirm-before-destructive-action prompt. Wired through `confirmAction(title, message, callback)` + a single `pendingConfirmCallback` slot. Closes via OK (runs callback then reloads), Cancel, X, ESC, or overlay click (latter four cancel the action).
+
 ## Schema (`db/simply_bank_db_script.sql`)
 
 Tables and FK order: `user_account`, `client`, `employee`, `user_account_client`, `user_account_employee`, `bank_account`, `bank_account_client`, `transaction`. Every table carries `create_date` / `modify_date` / `delete_date` for soft delete (except `transaction`, which is immutable).

--- a/src/main/resources/static/js/management.js
+++ b/src/main/resources/static/js/management.js
@@ -21,16 +21,23 @@ var ManagementAPI = {
 // CREDENTIAL MODAL (new user credentials, password resets)
 // ============================================================
 
-function showCredentialsModal(title, description, login, password) {
+var reloadAfterCredentialClose = false;
+
+function showCredentialsModal(title, description, login, password, reloadOnClose) {
     $("#credentialModalTitle").text(title);
     $("#credentialModalDescription").text(description);
     $("#credentialModalLogin").text(login || "");
     $("#credentialModalPassword").text(password || "");
+    reloadAfterCredentialClose = !!reloadOnClose;
     $("#credentialModalOverlay").addClass("open");
 }
 
 function closeCredentialsModal() {
     $("#credentialModalOverlay").removeClass("open");
+    if (reloadAfterCredentialClose) {
+        reloadAfterCredentialClose = false;
+        window.location.reload();
+    }
 }
 
 function copyCredentials() {
@@ -71,7 +78,6 @@ function confirmAction(title, message, callback) {
 
 function closeConfirmModal() {
     $("#confirmModalOverlay").removeClass("open");
-    pendingConfirmCallback = null;
 }
 
 // ============================================================
@@ -144,7 +150,8 @@ function submitClient() {
                     "Client Created",
                     "Copy these credentials now \u2014 they will not be shown again.",
                     response.login,
-                    response.generatedPassword
+                    response.generatedPassword,
+                    true
                 );
             }
         })
@@ -354,6 +361,7 @@ function submitEditClient() {
     ajax(ManagementAPI.CLIENT + "/" + encodeURIComponent(clientId), "PUT", data)
         .done(function () {
             notify("Client updated successfully", "success");
+            setTimeout(function () { window.location.reload(); }, 800);
         })
         .fail(function (jqxhr) {
             console.error("[submitEditClient] PUT " + ManagementAPI.CLIENT + "/" + clientId + " failed:", jqxhr);
@@ -387,31 +395,51 @@ function deleteClient() {
         return;
     }
 
-    confirmAction("Delete Client", "Are you sure you want to delete client #" + clientId + "? This action cannot be undone.", function () {
-        $("#btnDeleteClient").prop("disabled", true).html("Deleting\u2026");
+    $("#btnDeleteClient").prop("disabled", true).html("Loading\u2026");
 
-        ajax(ManagementAPI.CLIENT + "/" + encodeURIComponent(clientId), "DELETE")
-            .done(function () {
-                notify("Client deleted successfully", "success");
-                $("#deleteClientId").val("");
-            })
-            .fail(function (jqxhr) {
-                console.error("[deleteClient] DELETE " + ManagementAPI.CLIENT + "/" + clientId + " failed:", jqxhr);
-                var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
-                    ? jqxhr.responseJSON.message
-                    : "Failed to delete client";
-                notify(msg, "error");
-            })
-            .always(function () {
-                $("#btnDeleteClient").prop("disabled", false).html(
-                    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
-                        '<polyline points="3 6 5 6 21 6"/>' +
-                        '<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>' +
-                    '</svg> Delete Client'
-                );
+    ajax(ManagementAPI.CLIENT + "/" + encodeURIComponent(clientId), "GET")
+        .done(function (client) {
+            $("#btnDeleteClient").prop("disabled", false).html(DELETE_CLIENT_BUTTON_HTML);
+            var fullName = (client.firstName || "") + " " + (client.lastName || "");
+            var message = "Are you sure you want to delete client #" + clientId +
+                " (" + $.trim(fullName) + ")? This action cannot be undone.";
+
+            confirmAction("Delete Client", message, function () {
+                $("#btnDeleteClient").prop("disabled", true).html("Deleting\u2026");
+
+                ajax(ManagementAPI.CLIENT + "/" + encodeURIComponent(clientId), "DELETE")
+                    .done(function () {
+                        notify("Client deleted successfully", "success");
+                        $("#deleteClientId").val("");
+                        setTimeout(function () { window.location.reload(); }, 800);
+                    })
+                    .fail(function (jqxhr) {
+                        console.error("[deleteClient] DELETE " + ManagementAPI.CLIENT + "/" + clientId + " failed:", jqxhr);
+                        var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
+                            ? jqxhr.responseJSON.message
+                            : "Failed to delete client";
+                        notify(msg, "error");
+                    })
+                    .always(function () {
+                        $("#btnDeleteClient").prop("disabled", false).html(DELETE_CLIENT_BUTTON_HTML);
+                    });
             });
-    });
+        })
+        .fail(function (jqxhr) {
+            console.error("[deleteClient] GET " + ManagementAPI.CLIENT + "/" + clientId + " failed:", jqxhr);
+            var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
+                ? jqxhr.responseJSON.message
+                : "Client not found";
+            notify(msg, "error");
+            $("#btnDeleteClient").prop("disabled", false).html(DELETE_CLIENT_BUTTON_HTML);
+        });
 }
+
+var DELETE_CLIENT_BUTTON_HTML =
+    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
+        '<polyline points="3 6 5 6 21 6"/>' +
+        '<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>' +
+    '</svg> Delete Client';
 
 // ============================================================
 // EMPLOYEE: Add (existing)
@@ -461,7 +489,8 @@ function submitEmployee() {
                     "Employee Created",
                     "Copy these credentials now \u2014 they will not be shown again.",
                     response.login,
-                    response.generatedPassword
+                    response.generatedPassword,
+                    true
                 );
             }
         })
@@ -655,6 +684,7 @@ function submitEditEmployee() {
     ajax(ManagementAPI.EMPLOYEE + "/" + encodeURIComponent(empId), "PUT", data)
         .done(function () {
             notify("Employee updated successfully", "success");
+            setTimeout(function () { window.location.reload(); }, 800);
         })
         .fail(function (jqxhr) {
             console.error("[submitEditEmployee] PUT " + ManagementAPI.EMPLOYEE + "/" + empId + " failed:", jqxhr);
@@ -688,31 +718,51 @@ function deleteEmployee() {
         return;
     }
 
-    confirmAction("Delete Employee", "Are you sure you want to delete employee #" + empId + "? This action cannot be undone.", function () {
-        $("#btnDeleteEmployee").prop("disabled", true).html("Deleting\u2026");
+    $("#btnDeleteEmployee").prop("disabled", true).html("Loading\u2026");
 
-        ajax(ManagementAPI.EMPLOYEE + "/" + encodeURIComponent(empId), "DELETE")
-            .done(function () {
-                notify("Employee deleted successfully", "success");
-                $("#deleteEmpId").val("");
-            })
-            .fail(function (jqxhr) {
-                console.error("[deleteEmployee] DELETE " + ManagementAPI.EMPLOYEE + "/" + empId + " failed:", jqxhr);
-                var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
-                    ? jqxhr.responseJSON.message
-                    : "Failed to delete employee";
-                notify(msg, "error");
-            })
-            .always(function () {
-                $("#btnDeleteEmployee").prop("disabled", false).html(
-                    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
-                        '<polyline points="3 6 5 6 21 6"/>' +
-                        '<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>' +
-                    '</svg> Delete Employee'
-                );
+    ajax(ManagementAPI.EMPLOYEE + "/" + encodeURIComponent(empId), "GET")
+        .done(function (employee) {
+            $("#btnDeleteEmployee").prop("disabled", false).html(DELETE_EMPLOYEE_BUTTON_HTML);
+            var fullName = (employee.firstName || "") + " " + (employee.lastName || "");
+            var message = "Are you sure you want to delete employee #" + empId +
+                " (" + $.trim(fullName) + ")? This action cannot be undone.";
+
+            confirmAction("Delete Employee", message, function () {
+                $("#btnDeleteEmployee").prop("disabled", true).html("Deleting\u2026");
+
+                ajax(ManagementAPI.EMPLOYEE + "/" + encodeURIComponent(empId), "DELETE")
+                    .done(function () {
+                        notify("Employee deleted successfully", "success");
+                        $("#deleteEmpId").val("");
+                        setTimeout(function () { window.location.reload(); }, 800);
+                    })
+                    .fail(function (jqxhr) {
+                        console.error("[deleteEmployee] DELETE " + ManagementAPI.EMPLOYEE + "/" + empId + " failed:", jqxhr);
+                        var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
+                            ? jqxhr.responseJSON.message
+                            : "Failed to delete employee";
+                        notify(msg, "error");
+                    })
+                    .always(function () {
+                        $("#btnDeleteEmployee").prop("disabled", false).html(DELETE_EMPLOYEE_BUTTON_HTML);
+                    });
             });
-    });
+        })
+        .fail(function (jqxhr) {
+            console.error("[deleteEmployee] GET " + ManagementAPI.EMPLOYEE + "/" + empId + " failed:", jqxhr);
+            var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
+                ? jqxhr.responseJSON.message
+                : "Employee not found";
+            notify(msg, "error");
+            $("#btnDeleteEmployee").prop("disabled", false).html(DELETE_EMPLOYEE_BUTTON_HTML);
+        });
 }
+
+var DELETE_EMPLOYEE_BUTTON_HTML =
+    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
+        '<polyline points="3 6 5 6 21 6"/>' +
+        '<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>' +
+    '</svg> Delete Employee';
 
 // ============================================================
 // PASSWORD RESET (admin-only)
@@ -743,7 +793,8 @@ function resetPasswordFor(inputId, errorId, buttonId, defaultButtonHtml, entityL
                         entityLabel + " Password Reset",
                         "Share the new password with the " + entityLabel.toLowerCase() + " \u2014 it will not be shown again.",
                         response.login,
-                        response.newPassword
+                        response.newPassword,
+                        true
                     );
                 })
                 .fail(function (jqxhr) {
@@ -862,6 +913,7 @@ function deleteBankAccount() {
             .done(function () {
                 notify("Bank account deleted successfully", "success");
                 $("#deleteBaId").val("");
+                setTimeout(function () { window.location.reload(); }, 800);
             })
             .fail(function (jqxhr) {
                 console.error("[deleteBankAccount] DELETE " + ManagementAPI.BANK_ACCOUNT + "/" + baId + " failed:", jqxhr);
@@ -953,29 +1005,36 @@ $(document).ready(function () {
 
     // --- Confirm Modal ---
     $("#confirmModalOk").on("click", function () {
+        var cb = pendingConfirmCallback;
+        pendingConfirmCallback = null;
         closeConfirmModal();
-        if (typeof pendingConfirmCallback === "function") {
-            var cb = pendingConfirmCallback;
-            pendingConfirmCallback = null;
+        if (typeof cb === "function") {
             cb();
         }
     });
-    $("#confirmModalCancel, #confirmModalClose").on("click", closeConfirmModal);
+    $("#confirmModalCancel, #confirmModalClose").on("click", function () {
+        pendingConfirmCallback = null;
+        closeConfirmModal();
+    });
     $("#confirmModalOverlay").on("click", function (e) {
-        if (e.target === this) closeConfirmModal();
+        if (e.target === this) {
+            pendingConfirmCallback = null;
+            closeConfirmModal();
+        }
     });
 
     // --- Credential Modal ---
-    $("#credentialModalOk, #credentialModalClose").on("click", closeCredentialsModal);
+    // Closes only via the Done button — no outside-click, no ESC, no X close.
+    // Credentials are shown once and must be acknowledged explicitly.
+    $("#credentialModalOk").on("click", closeCredentialsModal);
     $("#credentialModalCopy").on("click", copyCredentials);
-    $("#credentialModalOverlay").on("click", function (e) {
-        if (e.target === this) closeCredentialsModal();
-    });
 
     $(document).on("keydown", function (e) {
         if (e.key === "Escape") {
-            if ($("#confirmModalOverlay").hasClass("open")) closeConfirmModal();
-            if ($("#credentialModalOverlay").hasClass("open")) closeCredentialsModal();
+            if ($("#confirmModalOverlay").hasClass("open")) {
+                pendingConfirmCallback = null;
+                closeConfirmModal();
+            }
         }
     });
 });

--- a/src/main/resources/templates/management.html
+++ b/src/main/resources/templates/management.html
@@ -657,11 +657,6 @@
         <div class="modal credential-modal">
             <div class="modal-header">
                 <h2 class="modal-title" id="credentialModalTitle">Generated Credentials</h2>
-                <button class="modal-close" id="credentialModalClose" type="button">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
-                    </svg>
-                </button>
             </div>
             <div class="modal-body">
                 <p class="credential-warning" id="credentialModalDescription">


### PR DESCRIPTION
## Summary

Fixed four UX and logic bugs on the `/management` page:

1. **Credentials modal closing unintentionally** — The modal shown after creating clients/employees or resetting passwords was dismissible via outside click, ESC, or the X button. Since credentials are shown exactly once and cannot be recovered, the modal now closes only via the explicit "Done" button.

2. **Stale form values after mutations** — After editing, deleting, or resetting a password, the page retained old form data. The page now reloads after successful mutations (immediately for edit/delete, after credentials modal dismissal for create/password-reset).

3. **Delete operations silently failing** — Pressing confirm on the delete modal did nothing. Root cause: `closeConfirmModal()` was nulling `pendingConfirmCallback` before the OK handler could invoke it. Fixed by capturing the callback before closing the modal.

4. **Delete confirmation lacked context** — The confirmation only showed entity ID. Now fetches and displays the entity's first + last name so admins can sanity-check before destruction.

## Key Changes

- **Credentials modal flow:**
  - Added `reloadOnClose` parameter to `showCredentialsModal()`
  - `closeCredentialsModal()` now calls `window.location.reload()` when flag is set
  - Removed outside-click, ESC, and X close handlers; only "Done" button dismisses
  - Removed X close button from modal header in template

- **Confirm modal callback fix:**
  - `closeConfirmModal()` no longer mutates `pendingConfirmCallback`
  - OK/Cancel/overlay/ESC handlers now manage callback state themselves
  - OK handler captures callback into local variable before closing modal

- **Delete operations enhanced:**
  - `deleteClient()` / `deleteEmployee()` now GET the entity first to fetch name
  - Confirmation message includes `firstName + lastName` for context
  - Page reloads after successful deletion (800ms delay to show toast)

- **Edit and other mutations:**
  - `submitEditClient()` / `submitEditEmployee()` reload after success
  - `deleteBankAccount()` reloads after success
  - `submitClient()` / `submitEmployee()` / `resetPasswordFor()` pass `reloadOnClose=true` to credentials modal

- **Documentation:**
  - Added "Static frontend" section to architecture doc describing template/JS structure and modal patterns

## Implementation Details

The delete callback bug was subtle: the original code called `closeConfirmModal()` first, which cleared `pendingConfirmCallback`, then checked if it was a function (always false). The fix captures the callback into a local variable before any state mutations, ensuring it executes after the modal closes.

Page reloads use `setTimeout(..., 800)` to allow toast notifications to remain visible before the reload.

https://claude.ai/code/session_01KKzSZ9XqGmee7nug8DbRpC