### PR TITLE
fix(tests): correct stubs around short-circuit logic and Spring redirect

### DIFF
--- a/src/test/java/com/alex/config/CustomAuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/alex/config/CustomAuthenticationSuccessHandlerTest.java
@@ -27,7 +27,7 @@ class CustomAuthenticationSuccessHandlerTest {
     @Test
     void onAuthenticationSuccess_clearsAttemptsAndRedirects() throws Exception {
         when(authentication.getName()).thenReturn("alice");
-        // After commit / clean response, Spring will sendRedirect to "/"
+        when(request.getContextPath()).thenReturn("");
         when(response.encodeRedirectURL("/")).thenReturn("/");
 
         CustomAuthenticationSuccessHandler handler = new CustomAuthenticationSuccessHandler(loginAttemptService);
@@ -40,6 +40,7 @@ class CustomAuthenticationSuccessHandlerTest {
     @Test
     void onAuthenticationSuccess_ioError_wrapsInSecurityRuntimeException() throws Exception {
         when(authentication.getName()).thenReturn("alice");
+        when(request.getContextPath()).thenReturn("");
         when(response.encodeRedirectURL("/")).thenReturn("/");
         org.mockito.Mockito.doThrow(new IOException("fail")).when(response).sendRedirect("/");
 

--- a/src/test/java/com/alex/config/LoginRateLimitFilterTest.java
+++ b/src/test/java/com/alex/config/LoginRateLimitFilterTest.java
@@ -30,7 +30,6 @@ class LoginRateLimitFilterTest {
     @Test
     void doFilter_nonLoginPath_continuesChain() throws Exception {
         when(request.getMethod()).thenReturn("GET");
-        when(request.getServletPath()).thenReturn("/accounts");
 
         new LoginRateLimitFilter(loginAttemptService).doFilter(request, response, chain);
 
@@ -41,7 +40,6 @@ class LoginRateLimitFilterTest {
     @Test
     void doFilter_getLoginPath_continuesChain() throws Exception {
         when(request.getMethod()).thenReturn("GET");
-        when(request.getServletPath()).thenReturn("/login");
 
         new LoginRateLimitFilter(loginAttemptService).doFilter(request, response, chain);
 

--- a/src/test/java/com/alex/repository/mapper/TransactionRowMapperTest.java
+++ b/src/test/java/com/alex/repository/mapper/TransactionRowMapperTest.java
@@ -82,7 +82,6 @@ class TransactionRowMapperTest {
         when(rs.getString("transaction_type")).thenReturn("DEPOSIT");
         when(rs.getString("currency")).thenReturn("PLN");
         when(rs.getLong("baf_id")).thenReturn(0L);
-        when(rs.wasNull()).thenReturn(true);
         when(rs.getLong("bat_id")).thenReturn(2L);
         when(rs.getString("bat_account_type")).thenReturn("CHECKING");
         when(rs.getString("bat_currency")).thenReturn("PLN");
@@ -203,7 +202,6 @@ class TransactionRowMapperTest {
         when(rs.getString("transaction_type")).thenReturn("TRANSFER");
         when(rs.getString("currency")).thenReturn("EUR");
         when(rs.getLong("baf_id")).thenReturn(0L);
-        when(rs.wasNull()).thenReturn(true);
         when(rs.getLong("bat_id")).thenThrow(new SQLException("inner-to"));
 
         assertThatThrownBy(() -> mapper.mapRow(rs, 1))


### PR DESCRIPTION
- TransactionRowMapperTest.mapRow_depositWithNullFromAccount: rs.wasNull() is short-circuited away by baf_id==0, so the only call comes from the bat path (id=2). Stubbing it to true forced mapBankAccountTo to return null. Drop the stub and rely on Mockito's default false.
- TransactionRowMapperTest.mapRow_sqlExceptionOnToAccount: same short-circuit means rs.wasNull() is never called. Stub was flagged unnecessary by strict-stubbing.
- CustomAuthenticationSuccessHandlerTest: DefaultRedirectStrategy prepends request.getContextPath(), which on a Mockito mock is null, producing a sendRedirect("null/") call that misses the encodeRedirectURL stub. Stub getContextPath() to "" so the URL is "/".
- LoginRateLimitFilterTest: GET method short-circuits before getServletPath(), making the path stub unnecessary under strict stubbing. Drop both unused stubs.