### PR TITLE
test(integration): replace @WithMockUser with real JWTs; collapse dup…

### DIFF
--- a/src/test/java/com/alex/config/LoginRateLimitFilterTest.java
+++ b/src/test/java/com/alex/config/LoginRateLimitFilterTest.java
@@ -28,17 +28,7 @@ class LoginRateLimitFilterTest {
     @Mock private FilterChain chain;
 
     @Test
-    void doFilter_nonLoginPath_continuesChain() throws Exception {
-        when(request.getMethod()).thenReturn("GET");
-
-        new LoginRateLimitFilter(loginAttemptService).doFilter(request, response, chain);
-
-        verify(chain).doFilter(request, response);
-        verifyNoInteractions(loginAttemptService);
-    }
-
-    @Test
-    void doFilter_getLoginPath_continuesChain() throws Exception {
+    void doFilter_getMethod_skipsRateLimit() throws Exception {
         when(request.getMethod()).thenReturn("GET");
 
         new LoginRateLimitFilter(loginAttemptService).doFilter(request, response, chain);

--- a/src/test/java/com/alex/controller/ApplicationControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/ApplicationControllerIntegrationTest.java
@@ -2,7 +2,6 @@ package com.alex.controller;
 
 import com.alex.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
@@ -30,57 +29,71 @@ class ApplicationControllerIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    @WithMockUser(username = "alice", roles = "CLIENT")
     void home_authenticated_returnsDashboardView() throws Exception {
-        mockMvc.perform(get("/"))
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        String token = generateToken("alice", "CLIENT");
+
+        mockMvc.perform(get("/").header("Authorization", bearer(token)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("dashboard"));
     }
 
     @Test
-    @WithMockUser(username = "alice", roles = "CLIENT")
     void homeAlias_authenticated_returnsDashboardView() throws Exception {
-        mockMvc.perform(get("/home"))
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        String token = generateToken("alice", "CLIENT");
+
+        mockMvc.perform(get("/home").header("Authorization", bearer(token)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("dashboard"));
     }
 
     @Test
-    @WithMockUser(username = "alice", roles = "CLIENT")
     void transactions_authenticated_returnsTransactionsView() throws Exception {
-        mockMvc.perform(get("/transactions"))
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        String token = generateToken("alice", "CLIENT");
+
+        mockMvc.perform(get("/transactions").header("Authorization", bearer(token)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("transactions"));
     }
 
     @Test
-    @WithMockUser(username = "alice", roles = "CLIENT")
     void newTransaction_authenticated_returnsNewTransactionView() throws Exception {
-        mockMvc.perform(get("/new-transaction"))
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        String token = generateToken("alice", "CLIENT");
+
+        mockMvc.perform(get("/new-transaction").header("Authorization", bearer(token)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("new-transaction"));
     }
 
     @Test
-    @WithMockUser(username = "alice", roles = "CLIENT")
     void accounts_authenticated_returnsAccountsView() throws Exception {
-        mockMvc.perform(get("/accounts"))
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        String token = generateToken("alice", "CLIENT");
+
+        mockMvc.perform(get("/accounts").header("Authorization", bearer(token)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("accounts"));
     }
 
     @Test
-    @WithMockUser(username = "alice", roles = "CLIENT")
     void account_authenticated_returnsAccountView() throws Exception {
-        mockMvc.perform(get("/account"))
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        String token = generateToken("alice", "CLIENT");
+
+        mockMvc.perform(get("/account").header("Authorization", bearer(token)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("account"));
     }
 
     @Test
-    @WithMockUser(username = "alice", roles = "CLIENT")
     void userProfile_authenticated_returnsUserProfileView() throws Exception {
-        mockMvc.perform(get("/user-profile"))
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        String token = generateToken("alice", "CLIENT");
+
+        mockMvc.perform(get("/user-profile").header("Authorization", bearer(token)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("user-profile"));
     }
@@ -88,24 +101,30 @@ class ApplicationControllerIntegrationTest extends BaseIntegrationTest {
     // /management is role-gated ---------------------------------------------------------------
 
     @Test
-    @WithMockUser(username = "alice", roles = "CLIENT")
     void management_asClient_isForbidden() throws Exception {
-        mockMvc.perform(get("/management"))
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
+        String token = generateToken("alice", "CLIENT");
+
+        mockMvc.perform(get("/management").header("Authorization", bearer(token)))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    @WithMockUser(username = "bob", roles = "EMPLOYEE")
     void management_asEmployee_returnsManagementView() throws Exception {
-        mockMvc.perform(get("/management"))
+        insertUserAccount(2L, "bob", "Password1!", "EMPLOYEE");
+        String token = generateToken("bob", "EMPLOYEE");
+
+        mockMvc.perform(get("/management").header("Authorization", bearer(token)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("management"));
     }
 
     @Test
-    @WithMockUser(username = "carol", roles = "ADMIN")
     void management_asAdmin_returnsManagementView() throws Exception {
-        mockMvc.perform(get("/management"))
+        insertUserAccount(3L, "carol", "Password1!", "ADMIN");
+        String token = generateToken("carol", "ADMIN");
+
+        mockMvc.perform(get("/management").header("Authorization", bearer(token)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("management"));
     }


### PR DESCRIPTION
…licate filter tests

ApplicationControllerIntegrationTest used @WithMockUser for all 10 authenticated cases, which short-circuits the JwtAuthenticationFilter chain. Tests would pass even if JWT parsing, role mapping, or UserAccountService.loadUserByUsername were broken. Replace with insertUserAccount + generateToken + bearer header, matching the rest of the controller integration tests.

LoginRateLimitFilterTest had two test methods (doFilter_nonLoginPath, doFilter_getLoginPath) whose bodies were identical after the recent removal of unused getServletPath() stubs. Both only stubbed getMethod()=GET, which short-circuits before any path check, so neither verified the path-branch they claimed to. Merge into a single doFilter_getMethod_skipsRateLimit test; the path branch is already covered by the four POST tests.