### PR TITLE
Revert "test(integration): replace @WithMockUser with real JWTs"

### DIFF
--- a/src/test/java/com/alex/controller/ApplicationControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/ApplicationControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package com.alex.controller;
 
 import com.alex.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
@@ -29,71 +30,57 @@ class ApplicationControllerIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
+    @WithMockUser(username = "alice", roles = "CLIENT")
     void home_authenticated_returnsDashboardView() throws Exception {
-        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
-        String token = generateToken("alice", "CLIENT");
-
-        mockMvc.perform(get("/").header("Authorization", bearer(token)))
+        mockMvc.perform(get("/"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("dashboard"));
     }
 
     @Test
+    @WithMockUser(username = "alice", roles = "CLIENT")
     void homeAlias_authenticated_returnsDashboardView() throws Exception {
-        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
-        String token = generateToken("alice", "CLIENT");
-
-        mockMvc.perform(get("/home").header("Authorization", bearer(token)))
+        mockMvc.perform(get("/home"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("dashboard"));
     }
 
     @Test
+    @WithMockUser(username = "alice", roles = "CLIENT")
     void transactions_authenticated_returnsTransactionsView() throws Exception {
-        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
-        String token = generateToken("alice", "CLIENT");
-
-        mockMvc.perform(get("/transactions").header("Authorization", bearer(token)))
+        mockMvc.perform(get("/transactions"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("transactions"));
     }
 
     @Test
+    @WithMockUser(username = "alice", roles = "CLIENT")
     void newTransaction_authenticated_returnsNewTransactionView() throws Exception {
-        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
-        String token = generateToken("alice", "CLIENT");
-
-        mockMvc.perform(get("/new-transaction").header("Authorization", bearer(token)))
+        mockMvc.perform(get("/new-transaction"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("new-transaction"));
     }
 
     @Test
+    @WithMockUser(username = "alice", roles = "CLIENT")
     void accounts_authenticated_returnsAccountsView() throws Exception {
-        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
-        String token = generateToken("alice", "CLIENT");
-
-        mockMvc.perform(get("/accounts").header("Authorization", bearer(token)))
+        mockMvc.perform(get("/accounts"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("accounts"));
     }
 
     @Test
+    @WithMockUser(username = "alice", roles = "CLIENT")
     void account_authenticated_returnsAccountView() throws Exception {
-        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
-        String token = generateToken("alice", "CLIENT");
-
-        mockMvc.perform(get("/account").header("Authorization", bearer(token)))
+        mockMvc.perform(get("/account"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("account"));
     }
 
     @Test
+    @WithMockUser(username = "alice", roles = "CLIENT")
     void userProfile_authenticated_returnsUserProfileView() throws Exception {
-        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
-        String token = generateToken("alice", "CLIENT");
-
-        mockMvc.perform(get("/user-profile").header("Authorization", bearer(token)))
+        mockMvc.perform(get("/user-profile"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("user-profile"));
     }
@@ -101,30 +88,24 @@ class ApplicationControllerIntegrationTest extends BaseIntegrationTest {
     // /management is role-gated ---------------------------------------------------------------
 
     @Test
+    @WithMockUser(username = "alice", roles = "CLIENT")
     void management_asClient_isForbidden() throws Exception {
-        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
-        String token = generateToken("alice", "CLIENT");
-
-        mockMvc.perform(get("/management").header("Authorization", bearer(token)))
+        mockMvc.perform(get("/management"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
+    @WithMockUser(username = "bob", roles = "EMPLOYEE")
     void management_asEmployee_returnsManagementView() throws Exception {
-        insertUserAccount(2L, "bob", "Password1!", "EMPLOYEE");
-        String token = generateToken("bob", "EMPLOYEE");
-
-        mockMvc.perform(get("/management").header("Authorization", bearer(token)))
+        mockMvc.perform(get("/management"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("management"));
     }
 
     @Test
+    @WithMockUser(username = "carol", roles = "ADMIN")
     void management_asAdmin_returnsManagementView() throws Exception {
-        insertUserAccount(3L, "carol", "Password1!", "ADMIN");
-        String token = generateToken("carol", "ADMIN");
-
-        mockMvc.perform(get("/management").header("Authorization", bearer(token)))
+        mockMvc.perform(get("/management"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("management"));
     }


### PR DESCRIPTION
The @WithMockUser approach was actually correct for these page tests. JwtAuthenticationFilter.doFilterInternal explicitly skips non-/api/ paths (line 38), so bearer tokens are intentionally ignored on HTML endpoints like /, /transactions, /management. Sending a token only made the requests fall through to the form-login redirect (302).

@WithMockUser still exercises what these tests are meant to cover: the authorizeHttpRequests role gates (e.g. /management requires EMPLOYEE/ADMIN) and view rendering. The JWT filter was never the target here.

The LoginRateLimitFilterTest deduplication from the previous commit remains.