### PR TITLE
fix(auth): delete JSESSIONID cookie on logout

### DIFF
--- a/src/main/java/com/alex/config/SecurityConfig.java
+++ b/src/main/java/com/alex/config/SecurityConfig.java
@@ -88,6 +88,9 @@ public class SecurityConfig {
                     )
                     .logout(logout -> logout
                             .logoutSuccessUrl("/login?logout")
+                            .deleteCookies("JSESSIONID")
+                            .invalidateHttpSession(true)
+                            .clearAuthentication(true)
                             .permitAll()
                     );
 


### PR DESCRIPTION
Without removing the cookie, the post-logout redirect to /login?logout arrives carrying a now-invalid session id, which trips invalidSessionUrl("/login?expired") and overrides the logout success parameter. Deleting the cookie (and explicitly invalidating the session
+ clearing authentication) lets the redirect land on /login?logout so the success banner shows.

https://claude.ai/code/session_01Paw4rDtv8B4F63oH4bosvs