### PR TITLE
feat(account): show full account number with copy button on detail page

### DIFF
--- a/src/main/resources/static/css/account.css
+++ b/src/main/resources/static/css/account.css
@@ -250,11 +250,38 @@ body {
     color: var(--gray-900);
     letter-spacing: -0.3px;
 }
+.hero-number-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
 .hero-number {
     font-size: 14px;
     color: var(--gray-500);
     letter-spacing: 1px;
+    font-variant-numeric: tabular-nums;
+    user-select: all;
 }
+.hero-copy-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: 1px solid var(--gray-200);
+    border-radius: 6px;
+    background: var(--white);
+    color: var(--gray-500);
+    cursor: pointer;
+    padding: 0;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.hero-copy-btn:hover {
+    background: var(--gray-100);
+    color: var(--blue-600);
+    border-color: var(--blue-100);
+}
+.hero-copy-btn:active { transform: translateY(1px); }
 .hero-currency {
     font-size: 11px;
     font-weight: 600;

--- a/src/main/resources/static/js/account.js
+++ b/src/main/resources/static/js/account.js
@@ -135,7 +135,7 @@ function renderAccountHero(account) {
     var currency      = (account.currency || "EUR").toUpperCase();
     var balance       = parseFloat(account.balance) || 0;
     var typeName      = formatAccountType(account.accountType);
-    var displayNumber = maskAccount(account.number);
+    var fullNumber    = account.number || "";
     var iconClass     = getTypeIconClass(account.accountType || "");
 
     var heroHtml =
@@ -146,9 +146,19 @@ function renderAccountHero(account) {
                 '</svg>' +
             '</div>' +
             '<div class="hero-info">' +
-                '<span class="hero-type">'     + escapeHtml(typeName)      + '</span>' +
-                '<span class="hero-number">'   + escapeHtml(displayNumber) + '</span>' +
-                '<span class="hero-currency">' + escapeHtml(currency)      + '</span>' +
+                '<span class="hero-type">'     + escapeHtml(typeName)   + '</span>' +
+                '<div class="hero-number-row">' +
+                    '<span class="hero-number" id="heroNumber">' + escapeHtml(fullNumber) + '</span>' +
+                    '<button type="button" class="hero-copy-btn" id="btnCopyNumber" ' +
+                            'data-number="' + escapeHtml(fullNumber) + '" ' +
+                            'title="Copy account number" aria-label="Copy account number">' +
+                        '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+                            '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>' +
+                            '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>' +
+                        '</svg>' +
+                    '</button>' +
+                '</div>' +
+                '<span class="hero-currency">' + escapeHtml(currency)   + '</span>' +
             '</div>' +
         '</div>' +
         '<div class="hero-right">' +
@@ -361,5 +371,31 @@ $(document).ready(function () {
         openDetail(txId);
     });
 
+    $(document).on("click", "#btnCopyNumber", function () {
+        var number = String($(this).data("number") || "");
+        if (!number) return;
+        copyToClipboard(number)
+            .then(function () { notify("Account number copied", "success"); })
+            .catch(function () { notify("Could not copy account number", "error"); });
+    });
+
     initModalClose();
 });
+
+function copyToClipboard(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+        return navigator.clipboard.writeText(text);
+    }
+    return new Promise(function (resolve, reject) {
+        var $ta = $('<textarea>').css({position: 'fixed', top: 0, left: 0, opacity: 0}).val(text).appendTo('body');
+        $ta[0].select();
+        try {
+            var ok = document.execCommand('copy');
+            $ta.remove();
+            ok ? resolve() : reject();
+        } catch (e) {
+            $ta.remove();
+            reject(e);
+        }
+    });
+}


### PR DESCRIPTION
Clients need their full account number to share it with senders. The account detail page now displays the unmasked number alongside a small copy-to-clipboard button (falls back to execCommand for non-secure contexts). The accounts list keeps masked numbers — masking only protects shoulder-surfing on the list view, not on the page you specifically opened to inspect one account.