### PR TITLE
Remove bank account management UI and restrict creation to clients only

### DIFF
--- a/src/main/java/com/alex/controller/BankAccountController.java
+++ b/src/main/java/com/alex/controller/BankAccountController.java
@@ -6,7 +6,6 @@ import com.alex.dto.SaveBankAccountRequest;
 import com.alex.dto.UserAccount;
 import com.alex.exception.AccessDeniedRuntimeException;
 import com.alex.exception.BankAccountNotFoundRuntimeException;
-import com.alex.exception.IllegalArgumentRuntimeException;
 import com.alex.service.IBankAccountService;
 import com.alex.service.IClientService;
 import com.alex.service.UserOwnershipService;
@@ -40,20 +39,15 @@ public class BankAccountController {
                                                        Principal principal) {
         UserAccount currentUser = ownershipService.resolveCurrentUser(principal);
 
-        Long clientId;
-        if (ownershipService.isClient(currentUser)) {
-            // CLIENT can only create accounts for themselves; ignore any clientId from the body.
-            clientId = clientService.findProfileByUserAccountId(currentUser.getId())
-                    .map(ClientProfile::getClientId)
-                    .orElseThrow(() -> new AccessDeniedRuntimeException(
-                            "Current user is not linked to a client profile"));
-        } else {
-            // EMPLOYEE/ADMIN must specify which client the account is for.
-            clientId = request.getClientId();
-            if (clientId == null) {
-                throw new IllegalArgumentRuntimeException("clientId is required");
-            }
+        if (!ownershipService.isClient(currentUser)) {
+            throw new AccessDeniedRuntimeException(
+                    "Only clients can open bank accounts");
         }
+
+        Long clientId = clientService.findProfileByUserAccountId(currentUser.getId())
+                .map(ClientProfile::getClientId)
+                .orElseThrow(() -> new AccessDeniedRuntimeException(
+                        "Current user is not linked to a client profile"));
 
         BankAccount bankAccount = bankAccountService.save(
                 clientId, request.getBankAccountType(), request.getBankAccountCurrency());

--- a/src/main/resources/static/js/dashboard.js
+++ b/src/main/resources/static/js/dashboard.js
@@ -223,18 +223,6 @@ function loadAccountBalances() {
         });
 }
 
-function loadCurrentUser() {
-    ajax("/api/auth/me", "GET")
-        .done(function (user) {
-            DashboardRenderer.renderWelcome(user);
-            initProfileLinks(user.id);
-        })
-        .fail(function (jqxhr) {
-            console.error("[loadCurrentUser] GET /api/auth/me failed:", jqxhr);
-            initProfileLinks();
-        });
-}
-
 // ============================================================
 // QUICK ACTION HANDLERS
 // ============================================================
@@ -263,39 +251,69 @@ function initQuickActions() {
 // INITIALIZATION
 // ============================================================
 
-$(document).ready(function () {
-    loadCurrentUser();
-    loadAccountBalances();
+function renderStaffWelcome(user) {
+    if (user && user.firstName) {
+        $("#staffWelcomeTitle").text("Welcome back, " + user.firstName);
+    }
+    if (user && (user.firstName || user.lastName)) {
+        var initials = (user.firstName || "").charAt(0) + (user.lastName || "").charAt(0);
+        $(".user-avatar").text(initials.toUpperCase());
+        $(".user-name").text((user.firstName || "") + " " + (user.lastName || "").charAt(0) + ".");
+    }
+}
 
-    // Load transactions after we know the user role and bank accounts
+function initStaffActions() {
+    $("#staffActionFindAccounts").on("click", function () {
+        window.location.href = "/accounts";
+    });
+    $("#staffActionFindTransactions").on("click", function () {
+        window.location.href = "/transactions";
+    });
+    $("#staffActionCreateUser").on("click", function () {
+        window.location.href = "/management";
+    });
+}
+
+$(document).ready(function () {
     ajax("/api/auth/me", "GET")
         .done(function (user) {
             var role = (user.role || "").toUpperCase();
+            initProfileLinks(user.id);
+
             if (role === "EMPLOYEE" || role === "ADMIN") {
-                loadTransactions(role, []);
-            } else {
-                BankAccountService.findAll()
-                    .done(function (accounts) {
-                        loadTransactions(role, Array.isArray(accounts) ? accounts : []);
-                    })
-                    .fail(function (jqxhr) {
-                        console.error("[ready] BankAccountService.findAll failed for role=" + role + ", loading transactions with empty account list:", jqxhr);
-                        loadTransactions(role, []);
-                    });
+                $("#clientDashboard").hide();
+                $("#staffDashboard").show();
+                renderStaffWelcome(user);
+                initStaffActions();
+                return;
             }
+
+            // CLIENT: render the full client dashboard
+            DashboardRenderer.renderWelcome(user);
+            loadAccountBalances();
+            BankAccountService.findAll()
+                .done(function (accounts) {
+                    loadTransactions(role, Array.isArray(accounts) ? accounts : []);
+                })
+                .fail(function (jqxhr) {
+                    console.error("[ready] BankAccountService.findAll failed for role=" + role + ", loading transactions with empty account list:", jqxhr);
+                    loadTransactions(role, []);
+                });
+            initQuickActions();
+
+            $("#clientDashboard .btn-primary").on("click", function () {
+                window.location.href = "/new-transaction";
+            });
+            $("#clientDashboard .transactions-section .btn-secondary").on("click", function () {
+                window.location.href = "/transactions";
+            });
         })
         .fail(function (jqxhr) {
-            console.error("[ready] GET /api/auth/me failed, loading transactions without role context:", jqxhr);
+            console.error("[ready] GET /api/auth/me failed:", jqxhr);
+            initProfileLinks();
+            // Fall back to client dashboard rendering
+            loadAccountBalances();
             loadTransactions("", []);
+            initQuickActions();
         });
-
-    initQuickActions();
-
-    $(".btn-primary").on("click", function () {
-        window.location.href = "/new-transaction";
-    });
-
-    $(".transactions-section .btn-secondary").on("click", function () {
-        window.location.href = "/transactions";
-    });
 });

--- a/src/main/resources/static/js/management.js
+++ b/src/main/resources/static/js/management.js
@@ -894,6 +894,9 @@ function applyRoleVisibility(role) {
         $("#tab-employees").removeClass("active").hide();
         $("#mgmtPageSubtitle").text("Manage clients");
 
+        // Password reset is admin-only on the backend; hide the card for employees.
+        $("#resetClientPasswordCard").hide();
+
         // If the employees tab was the active one for any reason, fall back to clients.
         if (!$(".mgmt-tab.active").is(":visible")) {
             $(".mgmt-tab").removeClass("active");

--- a/src/main/resources/static/js/management.js
+++ b/src/main/resources/static/js/management.js
@@ -1,7 +1,7 @@
 /**
  * SimplyBank — Management Page Controller
  *
- * Full CRUD management for Clients, Employees, and Bank Accounts.
+ * Full CRUD management for Clients and Employees.
  * Shared utilities (ajax, escapeHtml, notify, formatDate, etc.) are in common.js.
  */
 
@@ -12,7 +12,6 @@
 var ManagementAPI = {
     CLIENT:       "/api/client",
     EMPLOYEE:     "/api/employee",
-    BANK_ACCOUNT: "/api/bank_account",
     USER_ACCOUNT: "/api/user_account",
     AUTH_ME:      "/api/auth/me"
 };
@@ -828,112 +827,6 @@ function resetEmployeePassword() {
 }
 
 // ============================================================
-// BANK ACCOUNT: Create
-// ============================================================
-
-function validateBankAccountForm() {
-    var valid = true;
-
-    $(".field-error", "#createBankAccountForm").text("");
-    $(".field-input", "#createBankAccountForm").removeClass("invalid");
-
-    if (!$.trim($("#baClientId").val())) {
-        $("#baClientIdError").text("Client ID is required");
-        $("#baClientId").addClass("invalid");
-        valid = false;
-    }
-    if (!$("#baType").val()) {
-        $("#baTypeError").text("Account type is required");
-        $("#baType").addClass("invalid");
-        valid = false;
-    }
-    if (!$("#baCurrency").val()) {
-        $("#baCurrencyError").text("Currency is required");
-        $("#baCurrency").addClass("invalid");
-        valid = false;
-    }
-
-    return valid;
-}
-
-function submitCreateBankAccount() {
-    if (!validateBankAccountForm()) return;
-
-    var data = {
-        clientId:            parseInt($.trim($("#baClientId").val()), 10),
-        bankAccountType:     $("#baType").val(),
-        bankAccountCurrency: $("#baCurrency").val()
-    };
-
-    $("#btnCreateBankAccount").prop("disabled", true).html("Creating\u2026");
-
-    ajax(ManagementAPI.BANK_ACCOUNT, "POST", data)
-        .done(function () {
-            notify("Bank account created successfully", "success");
-            $("#createBankAccountForm")[0].reset();
-            $(".field-input", "#createBankAccountForm").removeClass("invalid");
-            $(".field-error", "#createBankAccountForm").text("");
-        })
-        .fail(function (jqxhr) {
-            console.error("[submitCreateBankAccount] POST " + ManagementAPI.BANK_ACCOUNT + " failed:", jqxhr);
-            var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
-                ? jqxhr.responseJSON.message
-                : "Failed to create bank account";
-            notify(msg, "error");
-        })
-        .always(function () {
-            $("#btnCreateBankAccount").prop("disabled", false).html(
-                '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
-                    '<line x1="12" y1="5" x2="12" y2="19"/>' +
-                    '<line x1="5" y1="12" x2="19" y2="12"/>' +
-                '</svg> Create Account'
-            );
-        });
-}
-
-// ============================================================
-// BANK ACCOUNT: Delete
-// ============================================================
-
-function deleteBankAccount() {
-    var baId = $.trim($("#deleteBaId").val());
-    $("#deleteBaIdError").text("");
-    $("#deleteBaId").removeClass("invalid");
-
-    if (!baId) {
-        $("#deleteBaIdError").text("Bank Account ID is required");
-        $("#deleteBaId").addClass("invalid");
-        return;
-    }
-
-    confirmAction("Delete Bank Account", "Are you sure you want to delete bank account #" + baId + "? This action cannot be undone.", function () {
-        $("#btnDeleteBankAccount").prop("disabled", true).html("Deleting\u2026");
-
-        ajax(ManagementAPI.BANK_ACCOUNT + "/" + encodeURIComponent(baId), "DELETE")
-            .done(function () {
-                notify("Bank account deleted successfully", "success");
-                $("#deleteBaId").val("");
-                setTimeout(function () { window.location.reload(); }, 800);
-            })
-            .fail(function (jqxhr) {
-                console.error("[deleteBankAccount] DELETE " + ManagementAPI.BANK_ACCOUNT + "/" + baId + " failed:", jqxhr);
-                var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
-                    ? jqxhr.responseJSON.message
-                    : "Failed to delete bank account";
-                notify(msg, "error");
-            })
-            .always(function () {
-                $("#btnDeleteBankAccount").prop("disabled", false).html(
-                    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
-                        '<polyline points="3 6 5 6 21 6"/>' +
-                        '<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>' +
-                    '</svg> Delete Account'
-                );
-            });
-    });
-}
-
-// ============================================================
 // HELPERS
 // ============================================================
 
@@ -953,11 +846,29 @@ function loadCurrentUser() {
         .done(function (user) {
             renderUserHeader(user);
             initProfileLinks(user.id);
+            applyRoleVisibility((user.role || "").toUpperCase());
         })
         .fail(function (jqxhr) {
             console.error("[loadCurrentUser] GET " + ManagementAPI.AUTH_ME + " failed:", jqxhr);
             initProfileLinks();
         });
+}
+
+function applyRoleVisibility(role) {
+    if (role !== "ADMIN") {
+        // EMPLOYEE only manages clients; hide the Employees tab entirely.
+        $("#mgmtTabEmployees").hide();
+        $("#tab-employees").removeClass("active").hide();
+        $("#mgmtPageSubtitle").text("Manage clients");
+
+        // If the employees tab was the active one for any reason, fall back to clients.
+        if (!$(".mgmt-tab.active").is(":visible")) {
+            $(".mgmt-tab").removeClass("active");
+            $('.mgmt-tab[data-tab="clients"]').addClass("active");
+            $(".mgmt-tab-content").removeClass("active");
+            $("#tab-clients").addClass("active");
+        }
+    }
 }
 
 $(document).ready(function () {
@@ -995,13 +906,6 @@ $(document).ready(function () {
     // --- Password Reset ---
     $("#btnResetClientPassword").on("click", resetClientPassword);
     $("#btnResetEmpPassword").on("click", resetEmployeePassword);
-
-    // --- Bank Account ---
-    $("#createBankAccountForm").on("submit", function (e) {
-        e.preventDefault();
-        submitCreateBankAccount();
-    });
-    $("#btnDeleteBankAccount").on("click", deleteBankAccount);
 
     // --- Confirm Modal ---
     $("#confirmModalOk").on("click", function () {

--- a/src/main/resources/static/js/management.js
+++ b/src/main/resources/static/js/management.js
@@ -68,10 +68,14 @@ function copyCredentials() {
 
 var pendingConfirmCallback = null;
 
-function confirmAction(title, message, callback) {
+function confirmAction(title, message, callback, okLabel, okClass) {
     pendingConfirmCallback = callback;
     $("#confirmModalTitle").text(title);
     $("#confirmModalMessage").text(message);
+    var $ok = $("#confirmModalOk");
+    $ok.text(okLabel || "Delete");
+    $ok.removeClass("btn-danger btn-primary");
+    $ok.addClass(okClass || "btn-danger");
     $("#confirmModalOverlay").addClass("open");
 }
 
@@ -778,36 +782,58 @@ function resetPasswordFor(inputId, errorId, buttonId, defaultButtonHtml, entityL
         return;
     }
 
-    confirmAction(
-        "Reset " + entityLabel + " Password",
-        "Generate a new password for user account #" + accountId + "? The current password will stop working immediately.",
-        function () {
-            $("#" + buttonId).prop("disabled", true).html("Resetting\u2026");
+    var profileBase = (entityLabel === "Client") ? ManagementAPI.CLIENT : ManagementAPI.EMPLOYEE;
+    var profileUrl = profileBase + "/profile?userAccountId=" + encodeURIComponent(accountId);
 
-            ajax(ManagementAPI.USER_ACCOUNT + "/" + encodeURIComponent(accountId) + "/password/reset", "POST")
-                .done(function (response) {
-                    notify("Password reset successfully", "success");
-                    $("#" + inputId).val("");
-                    showCredentialsModal(
-                        entityLabel + " Password Reset",
-                        "Share the new password with the " + entityLabel.toLowerCase() + " \u2014 it will not be shown again.",
-                        response.login,
-                        response.newPassword,
-                        true
-                    );
-                })
-                .fail(function (jqxhr) {
-                    console.error("[resetPasswordFor] POST " + ManagementAPI.USER_ACCOUNT + "/" + accountId + "/password/reset failed (entity=" + entityLabel + "):", jqxhr);
-                    var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
-                        ? jqxhr.responseJSON.message
-                        : "Failed to reset password";
-                    notify(msg, "error");
-                })
-                .always(function () {
-                    $("#" + buttonId).prop("disabled", false).html(defaultButtonHtml);
-                });
-        }
-    );
+    $("#" + buttonId).prop("disabled", true).html("Loading\u2026");
+
+    ajax(profileUrl, "GET")
+        .done(function (profile) {
+            $("#" + buttonId).prop("disabled", false).html(defaultButtonHtml);
+            var fullName = $.trim((profile.firstName || "") + " " + (profile.lastName || ""));
+            var nameSuffix = fullName ? " (" + fullName + ")" : "";
+
+            confirmAction(
+                "Reset " + entityLabel + " Password",
+                "Generate a new password for user account #" + accountId + nameSuffix + "? The current password will stop working immediately.",
+                function () {
+                    $("#" + buttonId).prop("disabled", true).html("Resetting\u2026");
+
+                    ajax(ManagementAPI.USER_ACCOUNT + "/" + encodeURIComponent(accountId) + "/password/reset", "POST")
+                        .done(function (response) {
+                            notify("Password reset successfully", "success");
+                            $("#" + inputId).val("");
+                            showCredentialsModal(
+                                entityLabel + " Password Reset",
+                                "Share the new password with the " + entityLabel.toLowerCase() + " \u2014 it will not be shown again.",
+                                response.login,
+                                response.newPassword,
+                                true
+                            );
+                        })
+                        .fail(function (jqxhr) {
+                            console.error("[resetPasswordFor] POST " + ManagementAPI.USER_ACCOUNT + "/" + accountId + "/password/reset failed (entity=" + entityLabel + "):", jqxhr);
+                            var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
+                                ? jqxhr.responseJSON.message
+                                : "Failed to reset password";
+                            notify(msg, "error");
+                        })
+                        .always(function () {
+                            $("#" + buttonId).prop("disabled", false).html(defaultButtonHtml);
+                        });
+                },
+                "Reset",
+                "btn-primary"
+            );
+        })
+        .fail(function (jqxhr) {
+            $("#" + buttonId).prop("disabled", false).html(defaultButtonHtml);
+            console.error("[resetPasswordFor] GET " + profileUrl + " failed (entity=" + entityLabel + "):", jqxhr);
+            var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
+                ? jqxhr.responseJSON.message
+                : entityLabel + " not found for user account #" + accountId;
+            notify(msg, "error");
+        });
 }
 
 var RESET_BUTTON_HTML =

--- a/src/main/resources/static/js/management.js
+++ b/src/main/resources/static/js/management.js
@@ -772,34 +772,41 @@ var DELETE_EMPLOYEE_BUTTON_HTML =
 // ============================================================
 
 function resetPasswordFor(inputId, errorId, buttonId, defaultButtonHtml, entityLabel) {
-    var accountId = $.trim($("#" + inputId).val());
+    var entityId = $.trim($("#" + inputId).val());
     $("#" + errorId).text("");
     $("#" + inputId).removeClass("invalid");
 
-    if (!accountId) {
-        $("#" + errorId).text("User Account ID is required");
+    if (!entityId) {
+        $("#" + errorId).text(entityLabel + " ID is required");
         $("#" + inputId).addClass("invalid");
         return;
     }
 
     var profileBase = (entityLabel === "Client") ? ManagementAPI.CLIENT : ManagementAPI.EMPLOYEE;
-    var profileUrl = profileBase + "/profile?userAccountId=" + encodeURIComponent(accountId);
+    var profileUrl = profileBase + "/" + encodeURIComponent(entityId) + "/profile";
 
     $("#" + buttonId).prop("disabled", true).html("Loading\u2026");
 
     ajax(profileUrl, "GET")
         .done(function (profile) {
             $("#" + buttonId).prop("disabled", false).html(defaultButtonHtml);
+
+            var userAccountId = profile.userAccountId;
+            if (!userAccountId) {
+                notify(entityLabel + " #" + entityId + " has no linked user account", "error");
+                return;
+            }
+
             var fullName = $.trim((profile.firstName || "") + " " + (profile.lastName || ""));
             var nameSuffix = fullName ? " (" + fullName + ")" : "";
 
             confirmAction(
                 "Reset " + entityLabel + " Password",
-                "Generate a new password for user account #" + accountId + nameSuffix + "? The current password will stop working immediately.",
+                "Generate a new password for " + entityLabel.toLowerCase() + " #" + entityId + nameSuffix + "? The current password will stop working immediately.",
                 function () {
                     $("#" + buttonId).prop("disabled", true).html("Resetting\u2026");
 
-                    ajax(ManagementAPI.USER_ACCOUNT + "/" + encodeURIComponent(accountId) + "/password/reset", "POST")
+                    ajax(ManagementAPI.USER_ACCOUNT + "/" + encodeURIComponent(userAccountId) + "/password/reset", "POST")
                         .done(function (response) {
                             notify("Password reset successfully", "success");
                             $("#" + inputId).val("");
@@ -812,7 +819,7 @@ function resetPasswordFor(inputId, errorId, buttonId, defaultButtonHtml, entityL
                             );
                         })
                         .fail(function (jqxhr) {
-                            console.error("[resetPasswordFor] POST " + ManagementAPI.USER_ACCOUNT + "/" + accountId + "/password/reset failed (entity=" + entityLabel + "):", jqxhr);
+                            console.error("[resetPasswordFor] POST " + ManagementAPI.USER_ACCOUNT + "/" + userAccountId + "/password/reset failed (entity=" + entityLabel + "):", jqxhr);
                             var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
                                 ? jqxhr.responseJSON.message
                                 : "Failed to reset password";
@@ -831,7 +838,7 @@ function resetPasswordFor(inputId, errorId, buttonId, defaultButtonHtml, entityL
             console.error("[resetPasswordFor] GET " + profileUrl + " failed (entity=" + entityLabel + "):", jqxhr);
             var msg = jqxhr.responseJSON && jqxhr.responseJSON.message
                 ? jqxhr.responseJSON.message
-                : entityLabel + " not found for user account #" + accountId;
+                : entityLabel + " #" + entityId + " not found";
             notify(msg, "error");
         });
 }

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -46,7 +46,7 @@
 
     <!-- Main Content -->
     <main class="main-content">
-        <div class="container">
+        <div class="container" id="clientDashboard">
             <!-- Welcome Section -->
             <section class="welcome-section">
                 <div>
@@ -286,6 +286,51 @@
                             </tr>
                         </tbody>
                     </table>
+                </div>
+            </section>
+        </div>
+
+        <!-- Staff Dashboard (EMPLOYEE / ADMIN) -->
+        <div class="container" id="staffDashboard" style="display:none;">
+            <section class="welcome-section">
+                <div>
+                    <h1 class="page-title" id="staffWelcomeTitle">Welcome back</h1>
+                    <p class="page-subtitle">Find accounts and transactions, or create new users from the management panel.</p>
+                </div>
+            </section>
+
+            <section class="quick-actions">
+                <h2 class="section-title">What would you like to do?</h2>
+                <div class="actions-grid" id="staffActionsGrid">
+                    <button class="action-card" type="button" id="staffActionFindAccounts">
+                        <div class="action-icon blue">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="2" y="5" width="20" height="14" rx="2"/>
+                                <line x1="2" y1="10" x2="22" y2="10"/>
+                            </svg>
+                        </div>
+                        <span class="action-label">Find accounts</span>
+                    </button>
+                    <button class="action-card" type="button" id="staffActionFindTransactions">
+                        <div class="action-icon green">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="3 6 9 6 9 18 15 18 15 6 21 6"/>
+                                <line x1="3" y1="12" x2="21" y2="12"/>
+                            </svg>
+                        </div>
+                        <span class="action-label">Find transactions</span>
+                    </button>
+                    <button class="action-card" type="button" id="staffActionCreateUser">
+                        <div class="action-icon purple">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+                                <circle cx="8.5" cy="7" r="4"/>
+                                <line x1="20" y1="8" x2="20" y2="14"/>
+                                <line x1="23" y1="11" x2="17" y2="11"/>
+                            </svg>
+                        </div>
+                        <span class="action-label">Create new user</span>
+                    </button>
                 </div>
             </section>
         </div>

--- a/src/main/resources/templates/management.html
+++ b/src/main/resources/templates/management.html
@@ -295,7 +295,7 @@
                 </section>
 
                 <!-- Reset Client Password -->
-                <section class="mgmt-card">
+                <section class="mgmt-card" id="resetClientPasswordCard">
                     <div class="mgmt-card-header">
                         <div class="mgmt-card-icon blue">
                             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/main/resources/templates/management.html
+++ b/src/main/resources/templates/management.html
@@ -308,8 +308,8 @@
                     </div>
                     <div class="form-grid">
                         <div class="field-group">
-                            <label class="field-label" for="resetClientAccountId">User Account ID <span class="req">*</span></label>
-                            <input class="field-input" type="number" id="resetClientAccountId" placeholder="Enter user account ID">
+                            <label class="field-label" for="resetClientAccountId">Client ID <span class="req">*</span></label>
+                            <input class="field-input" type="number" id="resetClientAccountId" placeholder="Enter client ID">
                             <div class="field-error" id="resetClientAccountIdError"></div>
                         </div>
                     </div>
@@ -531,8 +531,8 @@
                     </div>
                     <div class="form-grid">
                         <div class="field-group">
-                            <label class="field-label" for="resetEmpAccountId">User Account ID <span class="req">*</span></label>
-                            <input class="field-input" type="number" id="resetEmpAccountId" placeholder="Enter user account ID">
+                            <label class="field-label" for="resetEmpAccountId">Employee ID <span class="req">*</span></label>
+                            <input class="field-input" type="number" id="resetEmpAccountId" placeholder="Enter employee ID">
                             <div class="field-error" id="resetEmpAccountIdError"></div>
                         </div>
                     </div>

--- a/src/main/resources/templates/management.html
+++ b/src/main/resources/templates/management.html
@@ -52,15 +52,14 @@
             <section class="page-header">
                 <div class="page-header-left">
                     <h1 class="page-title">Management</h1>
-                    <p class="page-subtitle">Manage clients, employees, and bank accounts</p>
+                    <p class="page-subtitle" id="mgmtPageSubtitle">Manage clients and employees</p>
                 </div>
             </section>
 
             <!-- Tab Navigation -->
             <div class="mgmt-tabs">
                 <button class="mgmt-tab active" data-tab="clients">Clients</button>
-                <button class="mgmt-tab" data-tab="employees">Employees</button>
-                <button class="mgmt-tab" data-tab="accounts">Bank Accounts</button>
+                <button class="mgmt-tab" data-tab="employees" id="mgmtTabEmployees">Employees</button>
             </div>
 
             <!-- ============================================================
@@ -544,99 +543,6 @@
                                 <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
                             </svg>
                             Reset Password
-                        </button>
-                    </div>
-                </section>
-
-            </div>
-
-            <!-- ============================================================
-                 BANK ACCOUNTS TAB
-                 ============================================================ -->
-            <div class="mgmt-tab-content" id="tab-accounts">
-
-                <!-- Create Bank Account -->
-                <section class="mgmt-card">
-                    <div class="mgmt-card-header">
-                        <div class="mgmt-card-icon purple">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
-                                <line x1="1" y1="10" x2="23" y2="10"/>
-                            </svg>
-                        </div>
-                        <h2 class="mgmt-card-title">Create Bank Account</h2>
-                        <p class="mgmt-card-desc">Open a new bank account for an existing client</p>
-                    </div>
-                    <form id="createBankAccountForm" autocomplete="off">
-                        <div class="form-grid">
-                            <div class="field-group">
-                                <label class="field-label" for="baClientId">Client ID <span class="req">*</span></label>
-                                <input class="field-input" type="number" id="baClientId" placeholder="Enter client ID" required>
-                                <div class="field-error" id="baClientIdError"></div>
-                            </div>
-                            <div class="field-group">
-                                <label class="field-label" for="baType">Account Type <span class="req">*</span></label>
-                                <select class="field-input" id="baType" required>
-                                    <option value="">Select type</option>
-                                    <option value="CHECKING">Checking</option>
-                                    <option value="SAVING">Saving</option>
-                                    <option value="BUSINESS">Business</option>
-                                    <option value="FOREIGN_CURRENCY">Foreign Currency</option>
-                                </select>
-                                <div class="field-error" id="baTypeError"></div>
-                            </div>
-                            <div class="field-group">
-                                <label class="field-label" for="baCurrency">Currency <span class="req">*</span></label>
-                                <select class="field-input" id="baCurrency" required>
-                                    <option value="">Select currency</option>
-                                    <option value="PLN">PLN</option>
-                                    <option value="EUR">EUR</option>
-                                    <option value="GBP">GBP</option>
-                                    <option value="USD">USD</option>
-                                </select>
-                                <div class="field-error" id="baCurrencyError"></div>
-                            </div>
-                        </div>
-                        <div class="form-actions">
-                            <button class="btn btn-primary btn-purple" id="btnCreateBankAccount" type="submit">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                                    <line x1="12" y1="5" x2="12" y2="19"/>
-                                    <line x1="5" y1="12" x2="19" y2="12"/>
-                                </svg>
-                                Create Account
-                            </button>
-                        </div>
-                    </form>
-                </section>
-
-                <!-- Delete Bank Account -->
-                <section class="mgmt-card">
-                    <div class="mgmt-card-header">
-                        <div class="mgmt-card-icon red">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <polyline points="3 6 5 6 21 6"/>
-                                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
-                                <line x1="10" y1="11" x2="10" y2="17"/>
-                                <line x1="14" y1="11" x2="14" y2="17"/>
-                            </svg>
-                        </div>
-                        <h2 class="mgmt-card-title">Delete Bank Account</h2>
-                        <p class="mgmt-card-desc">Permanently close and remove a bank account</p>
-                    </div>
-                    <div class="form-grid">
-                        <div class="field-group">
-                            <label class="field-label" for="deleteBaId">Bank Account ID <span class="req">*</span></label>
-                            <input class="field-input" type="number" id="deleteBaId" placeholder="Enter bank account ID">
-                            <div class="field-error" id="deleteBaIdError"></div>
-                        </div>
-                    </div>
-                    <div class="form-actions">
-                        <button class="btn btn-danger" id="btnDeleteBankAccount" type="button">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                                <polyline points="3 6 5 6 21 6"/>
-                                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
-                            </svg>
-                            Delete Account
                         </button>
                     </div>
                 </section>

--- a/src/test/java/com/alex/controller/BankAccountControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/BankAccountControllerIntegrationTest.java
@@ -96,7 +96,7 @@ class BankAccountControllerIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    void save_asEmployee_returnsCreated() throws Exception {
+    void save_asEmployee_isForbidden() throws Exception {
         insertUserAccount(2L, "bob", "Password1!", "EMPLOYEE");
         insertClient(10L, "Alice", "A", "W", "M", "1", "ID");
         String token = generateToken("bob", "EMPLOYEE");
@@ -105,14 +105,12 @@ class BankAccountControllerIntegrationTest extends BaseIntegrationTest {
                         .header("Authorization", bearer(token))
                         .contentType("application/json")
                         .content(saveRequestJson(10L, "CHECKING", "EUR")))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.accountType").value("CHECKING"))
-                .andExpect(jsonPath("$.currency").value("EUR"))
-                .andExpect(jsonPath("$.balance").value(0));
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("Only clients can open bank accounts"));
     }
 
     @Test
-    void save_asAdmin_returnsCreated() throws Exception {
+    void save_asAdmin_isForbidden() throws Exception {
         insertUserAccount(3L, "carol", "Password1!", "ADMIN");
         insertClient(10L, "Alice", "A", "W", "M", "1", "ID");
         String token = generateToken("carol", "ADMIN");
@@ -121,34 +119,35 @@ class BankAccountControllerIntegrationTest extends BaseIntegrationTest {
                         .header("Authorization", bearer(token))
                         .contentType("application/json")
                         .content(saveRequestJson(10L, "SAVING", "USD")))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.accountType").value("SAVING"))
-                .andExpect(jsonPath("$.currency").value("USD"));
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("Only clients can open bank accounts"));
     }
 
     @Test
     void save_invalidType_returnsBadRequest() throws Exception {
-        insertUserAccount(2L, "bob", "Password1!", "EMPLOYEE");
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
         insertClient(10L, "Alice", "A", "W", "M", "1", "ID");
-        String token = generateToken("bob", "EMPLOYEE");
+        linkUserAccountToClient(1L, 10L);
+        String token = generateToken("alice", "CLIENT");
 
         mockMvc.perform(post("/api/bank_account")
                         .header("Authorization", bearer(token))
                         .contentType("application/json")
-                        .content(saveRequestJson(10L, "INVALID", "EUR")))
+                        .content(saveRequestJson(null, "INVALID", "EUR")))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
     void save_invalidCurrency_returnsBadRequest() throws Exception {
-        insertUserAccount(2L, "bob", "Password1!", "EMPLOYEE");
+        insertUserAccount(1L, "alice", "Password1!", "CLIENT");
         insertClient(10L, "Alice", "A", "W", "M", "1", "ID");
-        String token = generateToken("bob", "EMPLOYEE");
+        linkUserAccountToClient(1L, 10L);
+        String token = generateToken("alice", "CLIENT");
 
         mockMvc.perform(post("/api/bank_account")
                         .header("Authorization", bearer(token))
                         .contentType("application/json")
-                        .content(saveRequestJson(10L, "CHECKING", "XYZ")))
+                        .content(saveRequestJson(null, "CHECKING", "XYZ")))
                 .andExpect(status().isBadRequest());
     }
 


### PR DESCRIPTION
## Summary
This PR removes the bank account management interface from the staff dashboard and restricts bank account creation to client users only. Staff (employees and admins) can no longer create or delete bank accounts through the management panel.

## Key Changes

**Management Interface Removal:**
- Removed the entire "Bank Accounts" tab from the management page UI (HTML and JavaScript)
- Deleted `validateBankAccountForm()`, `submitCreateBankAccount()`, and `deleteBankAccount()` functions
- Removed bank account API endpoint reference from `ManagementAPI` object
- Updated page subtitle from "Manage clients, employees, and bank accounts" to "Manage clients and employees"

**Role-Based Access Control:**
- Added `applyRoleVisibility(role)` function to hide the Employees tab for non-admin users
- Employees now see only the Clients management tab
- Updated `loadCurrentUser()` to apply role-based visibility rules

**Bank Account Creation Authorization:**
- Modified `BankAccountController.saveBankAccount()` to reject non-client users with "Only clients can open bank accounts" error
- Clients can only create accounts for themselves (existing behavior preserved)
- Removed the ability for employees/admins to create accounts on behalf of clients

**Dashboard Refactoring:**
- Split dashboard into two views: client dashboard and staff dashboard
- Staff (EMPLOYEE/ADMIN) now see a simplified dashboard with quick action buttons to find accounts, find transactions, or create users
- Added `renderStaffWelcome()` and `initStaffActions()` functions for staff-specific UI
- Consolidated user loading logic in the main ready handler

**Test Updates:**
- Updated `BankAccountControllerIntegrationTest` to expect 403 Forbidden for employee/admin account creation attempts
- Changed test expectations from 201 Created to 403 Forbidden with appropriate error message
- Updated test cases to use client credentials where bank account creation is tested

## Implementation Details
- The role visibility check uses the user's role from the auth/me endpoint
- Staff dashboard provides navigation to accounts, transactions, and management pages via quick action cards
- Client dashboard remains unchanged with full account balance and transaction views

https://claude.ai/code/session_014bDJQfxC7bwQQeZy4p882b