### PR TITLE
Add daily deposit limit enforcement across client accounts

### DIFF
--- a/src/main/java/com/alex/controller/TransactionController.java
+++ b/src/main/java/com/alex/controller/TransactionController.java
@@ -48,13 +48,14 @@ public class TransactionController {
         if (!ownershipService.isClient(currentUser)) {
             throw new AccessDeniedRuntimeException("Only clients can deposit funds");
         }
-        if (!ownershipService.ownsBankAccount(currentUser, request.getBankAccountToId())) {
+        Set<Long> ownedIds = ownershipService.getOwnedBankAccountIds(currentUser);
+        if (!ownedIds.contains(request.getBankAccountToId())) {
             throw new AccessDeniedRuntimeException("You do not have access to the target bank account");
         }
 
         Transaction transaction = transactionService.deposit(
                 request.getBankAccountToId(), request.getAmount(),
-                request.getCurrency(), request.getDescription());
+                request.getCurrency(), request.getDescription(), ownedIds);
         return ResponseEntity.status(HttpStatus.CREATED).body(transaction);
     }
 

--- a/src/main/java/com/alex/repository/ITransactionRepository.java
+++ b/src/main/java/com/alex/repository/ITransactionRepository.java
@@ -2,8 +2,11 @@ package com.alex.repository;
 
 import com.alex.dto.Transaction;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface ITransactionRepository {
     Long save(Transaction transaction);
@@ -12,4 +15,5 @@ public interface ITransactionRepository {
     List<Transaction> findTransactionsByBankAccountFromId(Long bankAccountFromId);
     List<Transaction> findTransactionsByBankAccountToId(Long bankAccountToId);
     List<Transaction> findTransactionsBetweenBankAccounts(Long bankAccountFromId, Long bankAccountToId);
+    BigDecimal sumDepositsForAccountsBetween(Set<Long> bankAccountIds, LocalDateTime from, LocalDateTime toExclusive);
 }

--- a/src/main/java/com/alex/repository/TransactionRepository.java
+++ b/src/main/java/com/alex/repository/TransactionRepository.java
@@ -3,15 +3,21 @@ package com.alex.repository;
 import com.alex.dto.Transaction;
 import com.alex.repository.mapper.TransactionRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Component
 public class TransactionRepository implements ITransactionRepository{
 
     private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private final ICommonJdbcRepository commonJdbcRepository;
 
     private static final String BASE_QUERY = """
@@ -43,8 +49,11 @@ public class TransactionRepository implements ITransactionRepository{
                 LEFT JOIN bank_account AS bat ON t.bank_account_id_to = bat.id
             """;
 
-    public TransactionRepository(JdbcTemplate jdbcTemplate, ICommonJdbcRepository commonJdbcRepository) {
+    public TransactionRepository(JdbcTemplate jdbcTemplate,
+                                 NamedParameterJdbcTemplate namedParameterJdbcTemplate,
+                                 ICommonJdbcRepository commonJdbcRepository) {
         this.jdbcTemplate = jdbcTemplate;
+        this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
         this.commonJdbcRepository = commonJdbcRepository;
     }
 
@@ -93,5 +102,28 @@ public class TransactionRepository implements ITransactionRepository{
     public List<Transaction> findTransactionsBetweenBankAccounts(Long bankAccountFromId, Long bankAccountToId) {
         String query = BASE_QUERY + " WHERE t.bank_account_id_from = ? AND t.bank_account_id_to = ? ORDER BY t.create_date DESC";
         return jdbcTemplate.query(query, new TransactionRowMapper(), bankAccountFromId, bankAccountToId);
+    }
+
+    @Override
+    public BigDecimal sumDepositsForAccountsBetween(Set<Long> bankAccountIds,
+                                                    LocalDateTime from,
+                                                    LocalDateTime toExclusive) {
+        if (bankAccountIds == null || bankAccountIds.isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+        String query = """
+                SELECT COALESCE(SUM(amount), 0)
+                FROM transaction
+                WHERE transaction_type = 'DEPOSIT'
+                  AND bank_account_id_to IN (:ids)
+                  AND create_date >= :from
+                  AND create_date <  :toExclusive
+                """;
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("ids", bankAccountIds)
+                .addValue("from", from)
+                .addValue("toExclusive", toExclusive);
+        BigDecimal result = namedParameterJdbcTemplate.queryForObject(query, params, BigDecimal.class);
+        return result == null ? BigDecimal.ZERO : result;
     }
 }

--- a/src/main/java/com/alex/service/ITransactionService.java
+++ b/src/main/java/com/alex/service/ITransactionService.java
@@ -5,10 +5,11 @@ import com.alex.dto.Transaction;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface ITransactionService {
     Transaction transfer(Long bankAccountFromId, Long bankAccountToId, BigDecimal amount, String currency, String description);
-    Transaction deposit(Long bankAccountToId, BigDecimal amount, String currency, String description);
+    Transaction deposit(Long bankAccountToId, BigDecimal amount, String currency, String description, Set<Long> ownerBankAccountIds);
     Transaction withdraw(Long bankAccountFromId, BigDecimal amount, String currency, String description);
     Optional<Transaction> findById(Long id);
     List<Transaction> findAll();

--- a/src/main/java/com/alex/service/TransactionService.java
+++ b/src/main/java/com/alex/service/TransactionService.java
@@ -9,24 +9,30 @@ import com.alex.repository.ITransactionRepository;
 import com.alex.service.validation.CurrencyValidation;
 import com.alex.service.validation.IdValidation;
 import com.alex.service.validation.TransactionValidation;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 public class TransactionService implements ITransactionService {
 
     private final ITransactionRepository transactionRepository;
     private final IBankAccountService bankAccountService;
+    private final BigDecimal dailyDepositLimit;
 
     public TransactionService(ITransactionRepository transactionRepository,
-                              IBankAccountService bankAccountService) {
+                              IBankAccountService bankAccountService,
+                              @Value("${bank.deposit.daily-limit}") BigDecimal dailyDepositLimit) {
         this.transactionRepository = transactionRepository;
         this.bankAccountService = bankAccountService;
+        this.dailyDepositLimit = dailyDepositLimit;
     }
 
     @Transactional
@@ -75,7 +81,8 @@ public class TransactionService implements ITransactionService {
     @Transactional
     @Override
     public Transaction deposit(Long bankAccountToId, BigDecimal amount,
-                               String currency, String description) {
+                               String currency, String description,
+                               Set<Long> ownerBankAccountIds) {
         validateInputData(bankAccountToId, amount, currency, description);
 
         BankAccount bankAccountTo = bankAccountService.findByIdForUpdate(bankAccountToId)
@@ -83,6 +90,12 @@ public class TransactionService implements ITransactionService {
                         "Bank account not found with id: " + bankAccountToId));
 
         TransactionValidation.validateCurrencyMatch(bankAccountTo, currency);
+
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime startOfNextDay = startOfDay.plusDays(1);
+        BigDecimal depositedToday = transactionRepository.sumDepositsForAccountsBetween(
+                ownerBankAccountIds, startOfDay, startOfNextDay);
+        TransactionValidation.validateDailyDepositLimit(depositedToday, amount, dailyDepositLimit);
 
         bankAccountService.addToBalance(bankAccountToId, amount);
 

--- a/src/main/java/com/alex/service/validation/TransactionValidation.java
+++ b/src/main/java/com/alex/service/validation/TransactionValidation.java
@@ -33,6 +33,16 @@ public class TransactionValidation {
         }
     }
 
+    public static void validateDailyDepositLimit(BigDecimal alreadyDepositedToday,
+                                                 BigDecimal amount,
+                                                 BigDecimal dailyLimit) {
+        if (alreadyDepositedToday.add(amount).compareTo(dailyLimit) > 0) {
+            throw new IllegalStateRuntimeException(
+                    "Daily deposit limit of " + dailyLimit.toPlainString()
+                            + " exceeded. Already deposited today: " + alreadyDepositedToday.toPlainString());
+        }
+    }
+
     public static void validateCurrencyMatch(BankAccount account, String currency) {
         if (currency == null || account.getCurrency() == null) {
             return;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,6 @@ jwt.expiration-ms=3600000
 
 # CleanupService — purge expired login attempts every 15 minutes
 cleanup.login-attempts.interval-ms=900000
+
+# Daily deposit limit — total deposit amount allowed per client per calendar day (currency-agnostic, demo guardrail)
+bank.deposit.daily-limit=1000

--- a/src/test/java/com/alex/controller/TransactionControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/TransactionControllerIntegrationTest.java
@@ -190,6 +190,115 @@ class TransactionControllerIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
+    void deposit_exceedingDailyLimitOnSameAccount_returnsConflict() throws Exception {
+        setupAliceWithAccount(1L, 10L, 100L, new BigDecimal("0.00"), "PLN", "alice");
+        String token = generateToken("alice", "CLIENT");
+
+        // First deposit: 600 PLN — succeeds
+        String first = objectMapper.writeValueAsString(Map.of(
+                "bankAccountToId", 100L, "amount", 600.00,
+                "currency", "PLN", "description", "x"));
+        mockMvc.perform(post("/api/transaction/deposit")
+                        .header("Authorization", bearer(token))
+                        .contentType("application/json")
+                        .content(first))
+                .andExpect(status().isCreated());
+
+        // Second deposit: 500 PLN — 600 + 500 = 1100 > 1000 → 409
+        String second = objectMapper.writeValueAsString(Map.of(
+                "bankAccountToId", 100L, "amount", 500.00,
+                "currency", "PLN", "description", "x"));
+        mockMvc.perform(post("/api/transaction/deposit")
+                        .header("Authorization", bearer(token))
+                        .contentType("application/json")
+                        .content(second))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Daily deposit limit")));
+
+        assertThat(balanceOf(100L)).isEqualByComparingTo("600.00");
+    }
+
+    @Test
+    void deposit_exceedingDailyLimitAcrossCurrenciesAndAccounts_returnsConflict() throws Exception {
+        // Alice owns a PLN account (100) and an EUR account (200). 600 PLN + 500 EUR > 1000.
+        setupAliceWithAccount(1L, 10L, 100L, new BigDecimal("0.00"), "PLN", "alice");
+        insertBankAccount(200L, "100000000002", "CHECKING", "EUR", new BigDecimal("0.00"));
+        linkBankAccountToClient(200L, 10L);
+        String token = generateToken("alice", "CLIENT");
+
+        String first = objectMapper.writeValueAsString(Map.of(
+                "bankAccountToId", 100L, "amount", 600.00,
+                "currency", "PLN", "description", "x"));
+        mockMvc.perform(post("/api/transaction/deposit")
+                        .header("Authorization", bearer(token))
+                        .contentType("application/json")
+                        .content(first))
+                .andExpect(status().isCreated());
+
+        String second = objectMapper.writeValueAsString(Map.of(
+                "bankAccountToId", 200L, "amount", 500.00,
+                "currency", "EUR", "description", "x"));
+        mockMvc.perform(post("/api/transaction/deposit")
+                        .header("Authorization", bearer(token))
+                        .contentType("application/json")
+                        .content(second))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Daily deposit limit")));
+
+        assertThat(balanceOf(200L)).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    void deposit_atDailyLimitBoundary_succeeds() throws Exception {
+        setupAliceWithAccount(1L, 10L, 100L, new BigDecimal("0.00"), "PLN", "alice");
+        String token = generateToken("alice", "CLIENT");
+
+        String first = objectMapper.writeValueAsString(Map.of(
+                "bankAccountToId", 100L, "amount", 400.00,
+                "currency", "PLN", "description", "x"));
+        mockMvc.perform(post("/api/transaction/deposit")
+                        .header("Authorization", bearer(token))
+                        .contentType("application/json")
+                        .content(first))
+                .andExpect(status().isCreated());
+
+        // 400 + 600 = 1000 exactly → still allowed
+        String second = objectMapper.writeValueAsString(Map.of(
+                "bankAccountToId", 100L, "amount", 600.00,
+                "currency", "PLN", "description", "x"));
+        mockMvc.perform(post("/api/transaction/deposit")
+                        .header("Authorization", bearer(token))
+                        .contentType("application/json")
+                        .content(second))
+                .andExpect(status().isCreated());
+
+        assertThat(balanceOf(100L)).isEqualByComparingTo("1000.00");
+    }
+
+    @Test
+    void deposit_yesterdayDoesNotCountTowardsTodaysLimit() throws Exception {
+        setupAliceWithAccount(1L, 10L, 100L, new BigDecimal("0.00"), "PLN", "alice");
+        // Backdated DEPOSIT row: 800 yesterday should not count against today's bucket.
+        jdbcTemplate.update(
+                "INSERT INTO transaction (transaction_type, currency, amount, bank_account_id_from, bank_account_id_to, description, create_date)"
+                        + " VALUES ('DEPOSIT', 'PLN', 800.00, NULL, ?, 'yesterday', ?)",
+                100L, java.sql.Timestamp.valueOf(LocalDateTime.now().minusDays(1)));
+
+        String token = generateToken("alice", "CLIENT");
+        String body = objectMapper.writeValueAsString(Map.of(
+                "bankAccountToId", 100L, "amount", 900.00,
+                "currency", "PLN", "description", "today"));
+        mockMvc.perform(post("/api/transaction/deposit")
+                        .header("Authorization", bearer(token))
+                        .contentType("application/json")
+                        .content(body))
+                .andExpect(status().isCreated());
+
+        // Balance: 800 (backdated row only inserted the transaction, didn't touch balance) + 900 today
+        assertThat(balanceOf(100L)).isEqualByComparingTo("900.00");
+    }
+
+    @Test
     void deposit_asEmployee_updatesAnyAccount() throws Exception {
         insertUserAccount(2L, "bob", "Password1!", "EMPLOYEE");
         insertBankAccount(100L, "100000000001", "CHECKING", "EUR", new BigDecimal("50.00"));

--- a/src/test/java/com/alex/service/TransactionServiceTest.java
+++ b/src/test/java/com/alex/service/TransactionServiceTest.java
@@ -10,10 +10,10 @@ import com.alex.exception.IllegalArgumentRuntimeException;
 import com.alex.exception.IllegalStateRuntimeException;
 import com.alex.exception.NullPointerRuntimeException;
 import com.alex.repository.ITransactionRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -21,10 +21,12 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,10 +35,17 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class TransactionServiceTest {
 
+    private static final BigDecimal DAILY_LIMIT = new BigDecimal("1000");
+
     @Mock private ITransactionRepository transactionRepository;
     @Mock private IBankAccountService bankAccountService;
 
-    @InjectMocks private TransactionService service;
+    private TransactionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TransactionService(transactionRepository, bankAccountService, DAILY_LIMIT);
+    }
 
     private static BankAccount account(Long id, BigDecimal balance, Currency currency) {
         return new BankAccount(id, "num-" + id, BankAccountType.CHECKING, currency,
@@ -181,20 +190,20 @@ class TransactionServiceTest {
 
     @Test
     void deposit_nullId_throwsNullPointerRuntimeException() {
-        assertThatThrownBy(() -> service.deposit(null, BigDecimal.TEN, "EUR", "d"))
+        assertThatThrownBy(() -> service.deposit(null, BigDecimal.TEN, "EUR", "d", Set.of(1L)))
                 .isInstanceOf(NullPointerRuntimeException.class);
     }
 
     @Test
     void deposit_invalidCurrency_throwsIllegalArgumentRuntimeException() {
-        assertThatThrownBy(() -> service.deposit(1L, BigDecimal.TEN, "XYZ", "d"))
+        assertThatThrownBy(() -> service.deposit(1L, BigDecimal.TEN, "XYZ", "d", Set.of(1L)))
                 .isInstanceOf(IllegalArgumentRuntimeException.class);
     }
 
     @Test
     void deposit_accountNotFound_throwsBankAccountNotFoundRuntimeException() {
         when(bankAccountService.findByIdForUpdate(1L)).thenReturn(Optional.empty());
-        assertThatThrownBy(() -> service.deposit(1L, BigDecimal.TEN, "EUR", "d"))
+        assertThatThrownBy(() -> service.deposit(1L, BigDecimal.TEN, "EUR", "d", Set.of(1L)))
                 .isInstanceOf(BankAccountNotFoundRuntimeException.class);
     }
 
@@ -203,7 +212,7 @@ class TransactionServiceTest {
         when(bankAccountService.findByIdForUpdate(1L))
                 .thenReturn(Optional.of(account(1L, BigDecimal.TEN, Currency.USD)));
 
-        assertThatThrownBy(() -> service.deposit(1L, BigDecimal.TEN, "EUR", "d"))
+        assertThatThrownBy(() -> service.deposit(1L, BigDecimal.TEN, "EUR", "d", Set.of(1L)))
                 .isInstanceOf(IllegalArgumentRuntimeException.class)
                 .hasMessageContaining("Currency mismatch");
     }
@@ -212,9 +221,11 @@ class TransactionServiceTest {
     void deposit_happyPath_addsToBalanceAndSavesTransaction() {
         BankAccount to = account(1L, new BigDecimal("50.00"), Currency.EUR);
         when(bankAccountService.findByIdForUpdate(1L)).thenReturn(Optional.of(to));
+        when(transactionRepository.sumDepositsForAccountsBetween(eq(Set.of(1L)), any(), any()))
+                .thenReturn(BigDecimal.ZERO);
         when(transactionRepository.save(any(Transaction.class))).thenReturn(5L);
 
-        Transaction result = service.deposit(1L, new BigDecimal("20.00"), "EUR", null);
+        Transaction result = service.deposit(1L, new BigDecimal("20.00"), "EUR", null, Set.of(1L));
 
         assertThat(result.getId()).isEqualTo(5L);
         assertThat(result.getTransactionType()).isEqualTo(TransactionType.DEPOSIT);
@@ -223,6 +234,49 @@ class TransactionServiceTest {
 
         verify(bankAccountService).addToBalance(1L, new BigDecimal("20.00"));
         verify(bankAccountService, never()).subtractFromBalance(any(), any());
+    }
+
+    @Test
+    void deposit_atDailyLimitBoundary_succeeds() {
+        BankAccount to = account(1L, new BigDecimal("0.00"), Currency.EUR);
+        when(bankAccountService.findByIdForUpdate(1L)).thenReturn(Optional.of(to));
+        when(transactionRepository.sumDepositsForAccountsBetween(eq(Set.of(1L)), any(), any()))
+                .thenReturn(new BigDecimal("400"));
+        when(transactionRepository.save(any(Transaction.class))).thenReturn(5L);
+
+        Transaction result = service.deposit(1L, new BigDecimal("600"), "EUR", null, Set.of(1L));
+
+        assertThat(result.getAmount()).isEqualByComparingTo("600");
+        verify(bankAccountService).addToBalance(1L, new BigDecimal("600"));
+    }
+
+    @Test
+    void deposit_exceedsDailyLimit_throwsIllegalStateRuntimeException() {
+        BankAccount to = account(1L, new BigDecimal("0.00"), Currency.EUR);
+        when(bankAccountService.findByIdForUpdate(1L)).thenReturn(Optional.of(to));
+        when(transactionRepository.sumDepositsForAccountsBetween(eq(Set.of(1L)), any(), any()))
+                .thenReturn(new BigDecimal("999"));
+
+        assertThatThrownBy(() -> service.deposit(1L, new BigDecimal("2"), "EUR", null, Set.of(1L)))
+                .isInstanceOf(IllegalStateRuntimeException.class)
+                .hasMessageContaining("Daily deposit limit");
+
+        verify(bankAccountService, never()).addToBalance(any(), any());
+        verify(transactionRepository, never()).save(any());
+    }
+
+    @Test
+    void deposit_aggregatesAcrossOwnedAccountsRegardlessOfCurrency() {
+        // Two accounts owned by the same client. Sum across both already used 600 today (whatever the currency),
+        // so a 500 deposit on either must be rejected.
+        BankAccount to = account(2L, new BigDecimal("0.00"), Currency.USD);
+        when(bankAccountService.findByIdForUpdate(2L)).thenReturn(Optional.of(to));
+        when(transactionRepository.sumDepositsForAccountsBetween(eq(Set.of(1L, 2L)), any(), any()))
+                .thenReturn(new BigDecimal("600"));
+
+        assertThatThrownBy(() -> service.deposit(2L, new BigDecimal("500"), "USD", null, Set.of(1L, 2L)))
+                .isInstanceOf(IllegalStateRuntimeException.class)
+                .hasMessageContaining("Daily deposit limit");
     }
 
     // withdraw ------------------------------------------------------------------------------------

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -15,3 +15,5 @@ server.servlet.session.timeout=15m
 
 jwt.secret=test-only-secret-at-least-32-bytes-long-xxxxxxxxxxxxxxxxx
 jwt.expiration-ms=3600000
+
+bank.deposit.daily-limit=1000


### PR DESCRIPTION
## Summary
Implement a daily deposit limit feature that prevents clients from depositing more than a configurable amount (1000 by default) per calendar day, aggregated across all their owned accounts regardless of currency.

## Key Changes

- **Daily Limit Configuration**: Added `bank.deposit.daily-limit` property (default: 1000) to control the maximum deposit amount per client per day
- **Repository Enhancement**: Added `sumDepositsForAccountsBetween()` method to `TransactionRepository` using named parameters to query total deposits for a set of accounts within a time range
- **Service Validation**: Updated `TransactionService.deposit()` to:
  - Accept a `Set<Long> ownerBankAccountIds` parameter representing all accounts owned by the client
  - Query today's deposit total across all owned accounts
  - Validate that new deposit + existing deposits ≤ daily limit
  - Throw `IllegalStateRuntimeException` if limit would be exceeded
- **Validation Logic**: Added `validateDailyDepositLimit()` to `TransactionValidation` class
- **Controller Update**: Modified `TransactionController.deposit()` to:
  - Retrieve all owned account IDs via `ownershipService.getOwnedBankAccountIds()`
  - Pass owned account IDs to the service for limit checking
- **Test Coverage**: Added comprehensive integration and unit tests covering:
  - Single account limit enforcement
  - Cross-currency and cross-account aggregation
  - Boundary conditions (exactly at limit)
  - Previous day deposits not counting toward today's limit

## Implementation Details

- Daily limit is calculated per calendar day (midnight to midnight) using `LocalDate.now().atStartOfDay()`
- Limit aggregation is currency-agnostic (e.g., 600 PLN + 500 EUR counts as 1100 toward a 1000 limit)
- Only DEPOSIT transaction type is counted; transfers and withdrawals are excluded
- Validation occurs before balance updates to prevent partial state changes

https://claude.ai/code/session_01C9fdigxXNPy7vJTWAqnGsw