### PR TITLE
Exclude internal transfers from transaction summary totals

### DIFF
--- a/src/main/resources/static/js/transactions.js
+++ b/src/main/resources/static/js/transactions.js
@@ -54,6 +54,18 @@ function getDirection(tx) {
     return amt >= 0 ? "incoming" : "outgoing";
 }
 
+function isInternalTransfer(tx) {
+    var userIds = State.currentUserBankAccountIds;
+    if (!userIds || userIds.length === 0) return false;
+
+    var fromId = (tx.bankAccountFrom && tx.bankAccountFrom.id) || null;
+    var toId   = (tx.bankAccountTo   && tx.bankAccountTo.id)   || null;
+
+    return fromId !== null && toId !== null
+        && userIds.indexOf(fromId) !== -1
+        && userIds.indexOf(toId)   !== -1;
+}
+
 // ============================================================
 // DATA LOADING
 // ============================================================
@@ -414,6 +426,7 @@ function renderSummary(list) {
     var outTotal = 0;
 
     list.forEach(function (tx) {
+        if (isInternalTransfer(tx)) return;
         var amt = Math.abs(parseFloat(tx.amount) || 0);
         if (tx._direction === "incoming") inTotal  += amt;
         else                              outTotal += amt;


### PR DESCRIPTION
## Summary
Updated the transaction summary calculation to exclude internal transfers (transfers between user's own bank accounts) from incoming and outgoing totals.

## Key Changes
- Added `isInternalTransfer()` function to identify transfers where both the source and destination accounts belong to the current user
- Modified `renderSummary()` to skip internal transfers when calculating incoming and outgoing totals
- Internal transfers are now filtered out before amount aggregation, providing more accurate summary statistics that reflect only external transaction activity

## Implementation Details
The `isInternalTransfer()` function checks if:
- Both source (`bankAccountFrom`) and destination (`bankAccountTo`) accounts exist
- Both account IDs are present in the user's list of bank account IDs (`State.currentUserBankAccountIds`)

This ensures that money moving between a user's own accounts doesn't inflate the summary totals, giving a clearer picture of actual incoming and outgoing funds.

https://claude.ai/code/session_01FB9Aim2vWVaJeZW4pNYNvv