### PR TITLE
Support bank account transfers by account number

### DIFF
--- a/src/main/java/com/alex/controller/TransactionController.java
+++ b/src/main/java/com/alex/controller/TransactionController.java
@@ -2,7 +2,9 @@ package com.alex.controller;
 
 import com.alex.dto.*;
 import com.alex.exception.AccessDeniedRuntimeException;
+import com.alex.exception.BankAccountNotFoundRuntimeException;
 import com.alex.exception.TransactionNotFoundRuntimeException;
+import com.alex.service.IBankAccountService;
 import com.alex.service.ITransactionService;
 import com.alex.service.UserOwnershipService;
 import org.springframework.http.HttpStatus;
@@ -18,11 +20,14 @@ import java.util.Set;
 public class TransactionController {
 
     private final ITransactionService transactionService;
+    private final IBankAccountService bankAccountService;
     private final UserOwnershipService ownershipService;
 
     public TransactionController(ITransactionService transactionService,
+                                 IBankAccountService bankAccountService,
                                  UserOwnershipService ownershipService) {
         this.transactionService = transactionService;
+        this.bankAccountService = bankAccountService;
         this.ownershipService = ownershipService;
     }
 
@@ -36,8 +41,19 @@ public class TransactionController {
             throw new AccessDeniedRuntimeException("You do not have access to the source bank account");
         }
 
+        Long toId = request.getBankAccountToId();
+        if (toId == null) {
+            String toNumber = request.getBankAccountToNumber();
+            if (toNumber != null && !toNumber.isBlank()) {
+                toId = bankAccountService.findByNumber(toNumber)
+                        .orElseThrow(() -> new BankAccountNotFoundRuntimeException(
+                                "Bank account not found with number: " + toNumber))
+                        .getId();
+            }
+        }
+
         Transaction transaction = transactionService.transfer(
-                request.getBankAccountFromId(), request.getBankAccountToId(),
+                request.getBankAccountFromId(), toId,
                 request.getAmount(), request.getCurrency(), request.getDescription());
         return ResponseEntity.status(HttpStatus.CREATED).body(transaction);
     }

--- a/src/main/java/com/alex/dto/TransferRequest.java
+++ b/src/main/java/com/alex/dto/TransferRequest.java
@@ -6,14 +6,16 @@ public class TransferRequest {
 
     private final Long bankAccountFromId;
     private final Long bankAccountToId;
+    private final String bankAccountToNumber;
     private final BigDecimal amount;
     private final String currency;
     private final String description;
 
-    public TransferRequest(Long bankAccountFromId, Long bankAccountToId, BigDecimal amount,
-                           String currency, String description) {
+    public TransferRequest(Long bankAccountFromId, Long bankAccountToId, String bankAccountToNumber,
+                           BigDecimal amount, String currency, String description) {
         this.bankAccountFromId = bankAccountFromId;
         this.bankAccountToId = bankAccountToId;
+        this.bankAccountToNumber = bankAccountToNumber;
         this.amount = amount;
         this.currency = currency;
         this.description = description;
@@ -25,6 +27,10 @@ public class TransferRequest {
 
     public Long getBankAccountToId() {
         return bankAccountToId;
+    }
+
+    public String getBankAccountToNumber() {
+        return bankAccountToNumber;
     }
 
     public BigDecimal getAmount() {

--- a/src/main/resources/static/js/new-transaction.js
+++ b/src/main/resources/static/js/new-transaction.js
@@ -644,8 +644,8 @@ function buildPayload() {
             base.bankAccountFromId = parseInt(FormState.fromAccountId);
             break;
         case "PAYMENT":
-            base.bankAccountFromId     = parseInt(FormState.fromAccountId);
-            base.externalAccountNumber = FormState.externalAccount;
+            base.bankAccountFromId    = parseInt(FormState.fromAccountId);
+            base.bankAccountToNumber  = FormState.externalAccount;
             break;
     }
 


### PR DESCRIPTION
## Summary
Enhanced the transfer functionality to allow users to specify the recipient bank account by account number in addition to account ID. This provides more flexibility for users who may not know the recipient's account ID.

## Key Changes
- **TransactionController**: Added `IBankAccountService` dependency to resolve bank account numbers to IDs
  - Implemented logic to look up the recipient account by number when account ID is not provided
  - Throws `BankAccountNotFoundRuntimeException` if the account number cannot be found
  
- **TransferRequest DTO**: Extended to support both account ID and account number for the recipient
  - Added `bankAccountToNumber` field to the constructor and as a getter
  - Maintains backward compatibility by keeping `bankAccountToId` field

- **Frontend (new-transaction.js)**: Updated payload builder to use the new `bankAccountToNumber` field
  - Changed from `externalAccountNumber` to `bankAccountToNumber` for consistency with backend naming

## Implementation Details
The transfer endpoint now follows this logic:
1. If `bankAccountToId` is provided, use it directly
2. If `bankAccountToId` is null but `bankAccountToNumber` is provided, look up the account by number
3. If the account number lookup fails, throw an appropriate exception
4. Proceed with the transfer using the resolved account ID

This maintains backward compatibility while adding the new account number lookup capability.

https://claude.ai/code/session_01XnBmA4V8ULszioABdPHvzY