### PR TITLE
feat(payment): pre-flight currency check on recipient account

### DIFF
--- a/src/main/java/com/alex/controller/BankAccountController.java
+++ b/src/main/java/com/alex/controller/BankAccountController.java
@@ -1,5 +1,6 @@
 package com.alex.controller;
 
+import com.alex.dto.AccountCurrencyResponse;
 import com.alex.dto.BankAccount;
 import com.alex.dto.ClientProfile;
 import com.alex.dto.SaveBankAccountRequest;
@@ -78,6 +79,17 @@ public class BankAccountController {
                 () -> new BankAccountNotFoundRuntimeException(
                         "There is no bank account with provided number:" + number));
         return ResponseEntity.ok(bankAccount);
+    }
+
+    @GetMapping(path = "/by-number/{number}/currency")
+    public ResponseEntity<AccountCurrencyResponse> findBankAccountCurrencyByNumber(@PathVariable("number") String number,
+                                                                                   Principal principal) {
+        ownershipService.resolveCurrentUser(principal);
+
+        BankAccount bankAccount = bankAccountService.findByNumber(number).orElseThrow(
+                () -> new BankAccountNotFoundRuntimeException(
+                        "There is no bank account with provided number:" + number));
+        return ResponseEntity.ok(new AccountCurrencyResponse(bankAccount.getCurrency()));
     }
 
     @GetMapping(path = "/by-client/{clientId}")

--- a/src/main/java/com/alex/dto/AccountCurrencyResponse.java
+++ b/src/main/java/com/alex/dto/AccountCurrencyResponse.java
@@ -1,0 +1,23 @@
+package com.alex.dto;
+
+import com.alex.Currency;
+
+public class AccountCurrencyResponse {
+
+    private Currency currency;
+
+    public AccountCurrencyResponse() {
+    }
+
+    public AccountCurrencyResponse(Currency currency) {
+        this.currency = currency;
+    }
+
+    public Currency getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(Currency currency) {
+        this.currency = currency;
+    }
+}

--- a/src/main/resources/static/js/new-transaction.js
+++ b/src/main/resources/static/js/new-transaction.js
@@ -20,6 +20,7 @@
 var TxAPI = {
     AUTH_ME:       "/api/auth/me",
     BANK_ACCOUNT:  "/api/bank_account",
+    BANK_ACCOUNT_CURRENCY: "/api/bank_account/by-number/{number}/currency",
     TRANSFER:      "/api/transaction/transfer",
     DEPOSIT:       "/api/transaction/deposit",
     WITHDRAW:      "/api/transaction/withdraw"
@@ -46,7 +47,10 @@ var FormState = {
     category: "",
     accounts: [],
     currentUserId: null,
-    submitting: false
+    submitting: false,
+    recipientCurrency: null,
+    recipientLookupInFlight: false,
+    recipientLookupNotFound: false
 };
 
 // ============================================================
@@ -205,6 +209,18 @@ var TxValidation = {
         // External account — required for PAYMENT
         if (type === "PAYMENT") {
             if (!this.validateExternalAccount(formState.externalAccount)) {
+                valid = false;
+            } else if (formState.recipientLookupNotFound) {
+                this.addError("externalAccount", "Recipient account not found");
+                valid = false;
+            } else if (formState.recipientCurrency && formState.currency
+                    && formState.recipientCurrency !== formState.currency) {
+                this.addError("externalAccount",
+                    "Recipient account currency (" + formState.recipientCurrency +
+                    ") does not match your account's currency (" + formState.currency + ")");
+                valid = false;
+            } else if (!formState.recipientCurrency) {
+                this.addError("externalAccount", "Verifying recipient account…");
                 valid = false;
             }
         }
@@ -454,6 +470,7 @@ function initFieldEvents() {
         liveValidateSameAccount();
         refreshDrivingCurrency();
         liveValidateCurrencyMatch();
+        liveValidateRecipientCurrency();
     });
 
     $("#toAccount").on("change", function () {
@@ -466,6 +483,23 @@ function initFieldEvents() {
 
     $("#externalAccount").on("input", function () {
         FormState.externalAccount = $(this).val();
+        FormState.recipientCurrency = null;
+        FormState.recipientLookupNotFound = false;
+        $("#externalAccountError").text("");
+        $("#externalAccount").removeClass("invalid valid");
+    });
+
+    $("#externalAccount").on("blur", function () {
+        var value = $(this).val();
+        FormState.externalAccount = value;
+        if (FormState.transactionType !== "PAYMENT") return;
+        TxValidation.errors = {};
+        if (!TxValidation.validateExternalAccount(value)) {
+            $("#externalAccountError").text(TxValidation.errors.externalAccount);
+            $("#externalAccount").addClass("invalid").removeClass("valid");
+            return;
+        }
+        lookupRecipientCurrency(value.replace(/\s/g, ""));
     });
 
     $("#amount").on("input", function () {
@@ -567,6 +601,59 @@ function liveValidateCurrencyMatch() {
     }
 }
 
+function fetchRecipientCurrency(number) {
+    var url = TxAPI.BANK_ACCOUNT_CURRENCY.replace("{number}", encodeURIComponent(number));
+    return ajax(url, "GET");
+}
+
+function lookupRecipientCurrency(number) {
+    FormState.recipientLookupInFlight = true;
+    FormState.recipientCurrency = null;
+    FormState.recipientLookupNotFound = false;
+    $("#externalAccountError").text("Verifying recipient account…");
+
+    fetchRecipientCurrency(number)
+        .done(function (resp) {
+            FormState.recipientLookupInFlight = false;
+            if (FormState.externalAccount && FormState.externalAccount.replace(/\s/g, "") !== number) {
+                return;
+            }
+            FormState.recipientCurrency = resp && resp.currency ? String(resp.currency).toUpperCase() : null;
+            liveValidateRecipientCurrency();
+        })
+        .fail(function (jqxhr) {
+            FormState.recipientLookupInFlight = false;
+            if (FormState.externalAccount && FormState.externalAccount.replace(/\s/g, "") !== number) {
+                return;
+            }
+            if (jqxhr.status === 404) {
+                FormState.recipientLookupNotFound = true;
+                FormState.recipientCurrency = null;
+                $("#externalAccountError").text("Recipient account not found");
+                $("#externalAccount").addClass("invalid").removeClass("valid");
+            } else {
+                $("#externalAccountError").text("Could not verify recipient account");
+                $("#externalAccount").addClass("invalid").removeClass("valid");
+            }
+        });
+}
+
+function liveValidateRecipientCurrency() {
+    if (FormState.transactionType !== "PAYMENT") return;
+    if (!FormState.recipientCurrency || !FormState.currency) return;
+
+    if (FormState.recipientCurrency !== FormState.currency) {
+        $("#externalAccountError").text(
+            "Recipient account currency (" + FormState.recipientCurrency +
+            ") does not match your account's currency (" + FormState.currency + ")"
+        );
+        $("#externalAccount").addClass("invalid").removeClass("valid");
+    } else {
+        $("#externalAccountError").text("");
+        TxValidation.markValid("externalAccount");
+    }
+}
+
 // ============================================================
 // STEP 2 -> 3  (validate & move)
 // ============================================================
@@ -580,6 +667,17 @@ function initStep2Actions() {
         FormState.currency        = $("#currency").val();
         FormState.description     = $("#description").val();
         FormState.category        = $("#category").val();
+
+        if (FormState.transactionType === "PAYMENT"
+                && FormState.externalAccount
+                && !FormState.recipientCurrency
+                && !FormState.recipientLookupNotFound
+                && !FormState.recipientLookupInFlight) {
+            var cleaned = FormState.externalAccount.replace(/\s/g, "");
+            if (cleaned.length >= 8 && /^[A-Za-z0-9]+$/.test(cleaned)) {
+                lookupRecipientCurrency(cleaned);
+            }
+        }
 
         if (TxValidation.validateStep2(FormState)) {
             goToStep(3);
@@ -735,6 +833,9 @@ function resetForm() {
     FormState.description     = "";
     FormState.category        = "";
     FormState.submitting      = false;
+    FormState.recipientCurrency       = null;
+    FormState.recipientLookupInFlight = false;
+    FormState.recipientLookupNotFound = false;
 
     $(".type-option").removeClass("selected");
     $("#btnToStep2").prop("disabled", true);


### PR DESCRIPTION
For PAYMENT, the recipient is a free-form external account number that the form has no currency information for. Today a user can reach the Review & Confirm step with a recipient whose currency differs from the From account, and only see the "Currency mismatch" error after clicking Confirm.

- Add GET /api/bank_account/by-number/{number}/currency, a client- accessible endpoint that returns only the recipient's currency (not balance, owner, or id). The existing /by-number/{number} stays staff-only.
- AccountCurrencyResponse DTO carries just the Currency enum.
- Frontend: on blur of the recipient field (and on Review click as a safety net) fetch the recipient currency, compare against the locked From-account currency, and surface a 404 ("Recipient account not found") or a mismatch error inline. Step 2 -> Step 3 is blocked until the recipient is verified and matches.