### PR TITLE
Add CSRF protection and secure JWT configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# SimplyBank — required environment variables
+# Copy to `.env` (gitignored) and fill in real values, or export these in your shell /
+# IDE run configuration before starting the app. The application will NOT start unless
+# all three are set.
+
+# MySQL credentials for the application datasource (see spring.datasource.url in
+# application.properties for the host/database).
+DB_USERNAME=your_db_user
+DB_PASSWORD=your_db_password
+
+# JWT signing secret — MUST be at least 32 bytes and unique per environment.
+# Do not reuse the old committed default; the app rejects it at startup.
+# Generate one, e.g.:  openssl rand -base64 48
+JWT_SECRET=replace-with-a-unique-secret-of-at-least-32-bytes

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Local secrets / config (never commit) ###
+.env
+application-local.properties
+**/application-local.properties

--- a/README.md
+++ b/README.md
@@ -56,10 +56,30 @@ MySQL with JdbcTemplate for direct SQL control. Key design decisions:
    cd SimplyBank
    ```
 2. Set up the MySQL database using the scripts in the `db/` folder
-3. Configure your database connection in `application.properties`
+3. Configure required environment variables (see [Configuration](#configuration))
 4. Run the application
    ```bash
    ./mvnw spring-boot:run
    ```
+## Configuration
+Secrets are **not** committed to the repository — the application reads them from
+environment variables and will refuse to start if they are missing. Copy `.env.example`
+and provide real values:
+
+| Variable | Purpose |
+| --- | --- |
+| `DB_USERNAME` | MySQL datasource username |
+| `DB_PASSWORD` | MySQL datasource password |
+| `JWT_SECRET` | JWT signing secret — must be at least 32 bytes and unique per environment |
+
+Provide them in whichever way suits your workflow:
+- Export them in your shell before `./mvnw spring-boot:run`, or
+- Set them in your IDE run configuration, or
+- Create a gitignored `src/main/resources/application-local.properties` (activated with
+  `--spring.profiles.active=local`) holding the values for local development only.
+
+> The JWT secret rejects the old hard-coded default at startup. Generate a fresh one,
+> e.g. `openssl rand -base64 48`. Tests use a self-contained `application-test.properties`
+> and need no environment setup.
 ## Author
 **Aleksander Witek** — [GitHub](https://github.com/aleksanderWitek) · [LinkedIn](https://www.linkedin.com/in/aleksander-witek-dev/)

--- a/src/main/java/com/alex/config/JwtService.java
+++ b/src/main/java/com/alex/config/JwtService.java
@@ -14,6 +14,10 @@ import java.util.Date;
 @Service
 public class JwtService {
 
+    private static final int MIN_SECRET_BYTES = 32;
+    private static final String INSECURE_DEFAULT_SECRET =
+            "changeme-local-dev-secret-at-least-32-bytes-long-abcdef";
+
     private final String secret;
     private final long expirationMs;
     private SecretKey signingKey;
@@ -26,6 +30,18 @@ public class JwtService {
 
     @PostConstruct
     void init() {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalStateException(
+                    "jwt.secret must be configured (set the JWT_SECRET environment variable)");
+        }
+        if (secret.equals(INSECURE_DEFAULT_SECRET)) {
+            throw new IllegalStateException(
+                    "jwt.secret must not use the insecure default value; set a unique JWT_SECRET");
+        }
+        if (secret.getBytes(StandardCharsets.UTF_8).length < MIN_SECRET_BYTES) {
+            throw new IllegalStateException(
+                    "jwt.secret must be at least " + MIN_SECRET_BYTES + " bytes long");
+        }
         this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 

--- a/src/main/java/com/alex/config/SecurityConfig.java
+++ b/src/main/java/com/alex/config/SecurityConfig.java
@@ -1,15 +1,17 @@
 package com.alex.config;
 
 import com.alex.exception.SecurityRuntimeException;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
 @Configuration
 @EnableWebSecurity
@@ -34,7 +36,14 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) {
         try {
             http
-                    .csrf(AbstractHttpConfigurer::disable)
+                    // CSRF protection for the session-cookie (browser) flow. The token is stored in
+                    // a JS-readable cookie (XSRF-TOKEN) and echoed back via the X-XSRF-TOKEN header by
+                    // the frontend. Stateless requests authenticated with a Bearer token are exempt —
+                    // they carry no session cookie and therefore cannot be CSRF-forged.
+                    .csrf(csrf -> csrf
+                            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                            .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+                            .ignoringRequestMatchers(SecurityConfig::hasBearerToken))
                     .sessionManagement(sm -> sm
                             .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                             .invalidSessionUrl("/login?expired")
@@ -107,5 +116,10 @@ public class SecurityConfig {
         } catch (Exception e) {
             throw new SecurityRuntimeException("Failed to build security filter chain", e);
         }
+    }
+
+    private static boolean hasBearerToken(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        return authHeader != null && authHeader.startsWith("Bearer ");
     }
 }

--- a/src/main/java/com/alex/service/TransactionService.java
+++ b/src/main/java/com/alex/service/TransactionService.java
@@ -19,6 +19,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 @Service
 public class TransactionService implements ITransactionService {
@@ -82,9 +84,22 @@ public class TransactionService implements ITransactionService {
                                Set<Long> ownerBankAccountIds) {
         validateInputData(bankAccountToId, amount, currency, description);
 
-        BankAccount bankAccountTo = bankAccountService.findByIdForUpdate(bankAccountToId)
-                .orElseThrow(() -> new BankAccountNotFoundRuntimeException(
-                        "Bank account not found with id: " + bankAccountToId));
+        // Lock every account the daily-limit sum covers (all of the client's accounts, plus the
+        // credited account) in ascending id order — matching transfer()'s ordering to avoid
+        // deadlocks. Holding these locks before reading the daily total prevents concurrent
+        // deposits to different owned accounts from both passing the limit check (lost update).
+        SortedSet<Long> accountsToLock = new TreeSet<>(ownerBankAccountIds);
+        accountsToLock.add(bankAccountToId);
+
+        BankAccount bankAccountTo = null;
+        for (Long id : accountsToLock) {
+            BankAccount locked = bankAccountService.findByIdForUpdate(id)
+                    .orElseThrow(() -> new BankAccountNotFoundRuntimeException(
+                            "Bank account not found with id: " + id));
+            if (id.equals(bankAccountToId)) {
+                bankAccountTo = locked;
+            }
+        }
 
         TransactionValidation.validateCurrencyMatch(bankAccountTo, currency);
 

--- a/src/main/java/com/alex/service/validation/TransactionValidation.java
+++ b/src/main/java/com/alex/service/validation/TransactionValidation.java
@@ -29,7 +29,7 @@ public class TransactionValidation {
 
     public static void validateSufficientBalance(BankAccount bankAccount, BigDecimal amount) {
         if (bankAccount.getBalance().compareTo(amount) < 0) {
-            throw new IllegalStateRuntimeException("Insufficient balance on account: " + bankAccount.getNumber());
+            throw new IllegalStateRuntimeException("Insufficient balance for the requested amount");
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,16 +3,25 @@ spring.application.name=demo
 server.port=8081
 #home new PC
 spring.datasource.url=jdbc:mysql://localhost:3306/simply_bank_db?useUnicode=true&characterEncoding=utf8&useJDBCCompliantTimezoneShift=true&zeroDateTimeBehavior=convertToNull&useLegacyDatetimeCode=false&serverTimezone=Europe/Dublin
-spring.datasource.username=aleksDev
-spring.datasource.password=aleksDev123!
+# Credentials are supplied via environment variables — see .env.example and the README.
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+
+# HikariCP connection pool — explicit sizing/timeouts instead of relying on defaults
+spring.datasource.hikari.pool-name=SimplyBankHikariPool
+spring.datasource.hikari.maximum-pool-size=10
+spring.datasource.hikari.minimum-idle=2
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.max-lifetime=1800000
 
 management.endpoints.jmx.exposure.include=health,info
 
 # Session timeout — 15 minutes of inactivity
 server.servlet.session.timeout=15m
 
-# JWT settings
-jwt.secret=changeme-local-dev-secret-at-least-32-bytes-long-abcdef
+# JWT settings — the signing secret is supplied via the JWT_SECRET environment variable
+# (must be at least 32 bytes; see .env.example and the README).
+jwt.secret=${JWT_SECRET}
 jwt.expiration-ms=3600000
 
 # CleanupService — purge expired login attempts every 15 minutes

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -7,15 +7,29 @@
 // AJAX HELPER
 // ============================================================
 
+function getCsrfToken() {
+    const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+}
+
 function ajax(url, method, data) {
+    const type = (method || "GET").toUpperCase();
     const opts = {
         url,
-        type: method || "GET",
+        type,
         dataType: "json",
         contentType: "application/json; charset=UTF-8"
     };
-    if (data && (method === "POST" || method === "PUT")) {
+    if (data && (type === "POST" || type === "PUT")) {
         opts.data = JSON.stringify(data);
+    }
+    // Attach the CSRF token on state-changing, session-cookie-authenticated requests.
+    // (Bearer-token API clients are exempt server-side; the UI uses the session cookie.)
+    if (type !== "GET" && type !== "HEAD" && type !== "OPTIONS") {
+        const csrfToken = getCsrfToken();
+        if (csrfToken) {
+            opts.headers = { "X-XSRF-TOKEN": csrfToken };
+        }
     }
     return $.ajax(opts);
 }
@@ -310,6 +324,12 @@ function initLogoutMenu() {
         if (e.target === this) closeLogoutConfirm();
     });
     $("#logoutConfirmBtn").on("click", function () {
+        // Logout is a real form POST, so it needs the CSRF token as a hidden field.
+        const csrfToken = getCsrfToken();
+        if (csrfToken) {
+            $("#logoutForm").html('<input type="hidden" name="_csrf">');
+            $("#logoutForm").find("input[name='_csrf']").val(csrfToken);
+        }
         $("#logoutForm").trigger("submit");
     });
 }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -35,6 +35,7 @@
             </div>
 
             <form action="/login" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                 <div class="form-group">
                     <label for="username">Login</label>
                     <input type="text" id="username" name="username" required autofocus>

--- a/src/test/java/com/alex/config/JwtServiceTest.java
+++ b/src/test/java/com/alex/config/JwtServiceTest.java
@@ -2,20 +2,38 @@ package com.alex.config;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class JwtServiceTest {
 
     private static final String SECRET = "test-only-secret-at-least-32-bytes-long-xxxxxxxxxxxxxxxxx";
 
     private static JwtService newService(long expirationMs) throws Exception {
-        JwtService service = new JwtService(SECRET, expirationMs);
+        return newService(SECRET, expirationMs);
+    }
+
+    private static JwtService newService(String secret, long expirationMs) throws Exception {
+        JwtService service = new JwtService(secret, expirationMs);
+        invokeInit(service);
+        return service;
+    }
+
+    private static void invokeInit(JwtService service) throws Exception {
         Method init = JwtService.class.getDeclaredMethod("init");
         init.setAccessible(true);
-        init.invoke(service);
-        return service;
+        try {
+            init.invoke(service);
+        } catch (InvocationTargetException e) {
+            // Unwrap so tests can assert on the real cause thrown inside init().
+            if (e.getCause() instanceof RuntimeException re) {
+                throw re;
+            }
+            throw e;
+        }
     }
 
     @Test
@@ -71,5 +89,35 @@ class JwtServiceTest {
         String token = service.generateToken("bob", "ADMIN");
 
         assertThat(service.extractRole(token)).isEqualTo("ADMIN");
+    }
+
+    @Test
+    void init_nullSecret_throws() {
+        assertThatThrownBy(() -> newService(null, 60_000L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("jwt.secret must be configured");
+    }
+
+    @Test
+    void init_blankSecret_throws() {
+        assertThatThrownBy(() -> newService("   ", 60_000L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("jwt.secret must be configured");
+    }
+
+    @Test
+    void init_insecureDefaultSecret_throws() {
+        String insecureDefault = "changeme-local-dev-secret-at-least-32-bytes-long-abcdef";
+
+        assertThatThrownBy(() -> newService(insecureDefault, 60_000L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("insecure default");
+    }
+
+    @Test
+    void init_secretShorterThan32Bytes_throws() {
+        assertThatThrownBy(() -> newService("too-short-secret", 60_000L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("at least 32 bytes");
     }
 }

--- a/src/test/java/com/alex/controller/BankAccountControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/BankAccountControllerIntegrationTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
@@ -31,7 +32,8 @@ class BankAccountControllerIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void save_noToken_redirectsToLogin() throws Exception {
-        mockMvc.perform(post("/api/bank_account").contentType("application/json").content("{}"))
+        // CSRF passes (so we exercise the auth redirect, not a 403); no token still redirects.
+        mockMvc.perform(post("/api/bank_account").with(csrf()).contentType("application/json").content("{}"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }

--- a/src/test/java/com/alex/controller/ClientControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/ClientControllerIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,7 +39,7 @@ class ClientControllerIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void saveClient_noToken_redirectsToLogin() throws Exception {
-        mockMvc.perform(post("/api/client").contentType("application/json").content(clientJson("A", "B")))
+        mockMvc.perform(post("/api/client").with(csrf()).contentType("application/json").content(clientJson("A", "B")))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }

--- a/src/test/java/com/alex/controller/EmployeeControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/EmployeeControllerIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -28,7 +29,7 @@ class EmployeeControllerIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void saveEmployee_noToken_redirectsToLogin() throws Exception {
-        mockMvc.perform(post("/api/employee").contentType("application/json").content("{}"))
+        mockMvc.perform(post("/api/employee").with(csrf()).contentType("application/json").content("{}"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }

--- a/src/test/java/com/alex/controller/TransactionControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/TransactionControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -42,7 +43,7 @@ class TransactionControllerIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void transfer_noToken_redirectsToLogin() throws Exception {
-        mockMvc.perform(post("/api/transaction/transfer").contentType("application/json").content("{}"))
+        mockMvc.perform(post("/api/transaction/transfer").with(csrf()).contentType("application/json").content("{}"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }

--- a/src/test/java/com/alex/controller/UserAccountControllerIntegrationTest.java
+++ b/src/test/java/com/alex/controller/UserAccountControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -232,7 +233,7 @@ class UserAccountControllerIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void resetPassword_noToken_redirectsToLogin() throws Exception {
-        mockMvc.perform(post("/api/user_account/1/password/reset"))
+        mockMvc.perform(post("/api/user_account/1/password/reset").with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }

--- a/src/test/java/com/alex/service/TransactionServiceTest.java
+++ b/src/test/java/com/alex/service/TransactionServiceTest.java
@@ -270,6 +270,9 @@ class TransactionServiceTest {
         // Two accounts owned by the same client. Sum across both already used 600 today (whatever the currency),
         // so a 500 deposit on either must be rejected.
         BankAccount to = account(2L, new BigDecimal("0.00"), Currency.USD);
+        // Both owned accounts are locked before the daily total is read, so both must be stubbed.
+        when(bankAccountService.findByIdForUpdate(1L))
+                .thenReturn(Optional.of(account(1L, BigDecimal.TEN, Currency.EUR)));
         when(bankAccountService.findByIdForUpdate(2L)).thenReturn(Optional.of(to));
         when(transactionRepository.sumDepositsForAccountsBetween(eq(Set.of(1L, 2L)), any(), any()))
                 .thenReturn(new BigDecimal("600"));
@@ -277,6 +280,28 @@ class TransactionServiceTest {
         assertThatThrownBy(() -> service.deposit(2L, new BigDecimal("500"), "USD", null, Set.of(1L, 2L)))
                 .isInstanceOf(IllegalStateRuntimeException.class)
                 .hasMessageContaining("Daily deposit limit");
+    }
+
+    @Test
+    void deposit_locksAllOwnedAccountsInAscendingOrderBeforeReadingDailyTotal() {
+        BankAccount to = account(2L, new BigDecimal("0.00"), Currency.EUR);
+        when(bankAccountService.findByIdForUpdate(1L))
+                .thenReturn(Optional.of(account(1L, BigDecimal.TEN, Currency.EUR)));
+        when(bankAccountService.findByIdForUpdate(2L)).thenReturn(Optional.of(to));
+        when(transactionRepository.sumDepositsForAccountsBetween(eq(Set.of(1L, 2L)), any(), any()))
+                .thenReturn(BigDecimal.ZERO);
+        when(transactionRepository.save(any(Transaction.class))).thenReturn(7L);
+
+        service.deposit(2L, new BigDecimal("10.00"), "EUR", null, Set.of(1L, 2L));
+
+        // All owned accounts are pessimistically locked (ascending id, like transfer()) BEFORE the
+        // daily total is summed — this serialization is what prevents two concurrent deposits to
+        // different owned accounts from both passing the daily-limit check.
+        InOrder order = inOrder(bankAccountService, transactionRepository);
+        order.verify(bankAccountService).findByIdForUpdate(1L);
+        order.verify(bankAccountService).findByIdForUpdate(2L);
+        order.verify(transactionRepository).sumDepositsForAccountsBetween(eq(Set.of(1L, 2L)), any(), any());
+        order.verify(bankAccountService).addToBalance(2L, new BigDecimal("10.00"));
     }
 
     // withdraw ------------------------------------------------------------------------------------

--- a/src/test/java/com/alex/service/validation/TransactionValidationTest.java
+++ b/src/test/java/com/alex/service/validation/TransactionValidationTest.java
@@ -99,7 +99,9 @@ class TransactionValidationTest {
         assertThatThrownBy(() ->
                 TransactionValidation.validateSufficientBalance(account, new BigDecimal("10.00")))
                 .isInstanceOf(IllegalStateRuntimeException.class)
-                .hasMessageContaining("Insufficient balance on account: 123456789012");
+                .hasMessageContaining("Insufficient balance")
+                // The account number must not leak into the error message (finding #5).
+                .hasMessageNotContaining("123456789012");
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR implements CSRF protection for session-cookie authenticated requests and enforces secure JWT secret configuration at startup. It also fixes a concurrency issue in the deposit service and improves error message security.

## Key Changes

### Security & Configuration
- **CSRF Protection**: Enabled Spring Security's CSRF protection using cookie-based tokens (XSRF-TOKEN) for session-authenticated requests. Bearer token requests are exempt. Frontend updated to extract and send CSRF tokens via X-XSRF-TOKEN header.
- **JWT Secret Validation**: Added startup validation in `JwtService.init()` to reject:
  - Null or blank secrets
  - The old hard-coded default value (`changeme-local-dev-secret-at-least-32-bytes-long-abcdef`)
  - Secrets shorter than 32 bytes
- **Environment Variables**: Moved database credentials and JWT secret to environment variables (`DB_USERNAME`, `DB_PASSWORD`, `JWT_SECRET`). Added `.env.example` template and updated `.gitignore` to prevent accidental secret commits.
- **Documentation**: Updated README with configuration section explaining required environment variables and setup options.

### Bug Fixes & Improvements
- **Deposit Concurrency**: Fixed lost-update race condition in `TransactionService.deposit()` by locking all owned accounts (in ascending ID order) before reading the daily deposit total. This prevents concurrent deposits to different owned accounts from both passing the limit check.
- **Error Message Security**: Removed account number from insufficient balance error message to prevent information leakage (finding #5).
- **Test Improvements**: 
  - Enhanced `JwtServiceTest` with four new tests validating secret configuration rules
  - Added `TransactionServiceTest.deposit_locksAllOwnedAccountsInAscendingOrderBeforeReadingDailyTotal()` to verify lock ordering
  - Updated integration tests to include CSRF tokens in POST/PUT requests
  - Improved reflection-based `init()` invocation to properly unwrap `InvocationTargetException`

### Frontend Updates
- Added `getCsrfToken()` helper to extract XSRF-TOKEN from cookies
- Updated `ajax()` function to automatically attach CSRF token header for state-changing requests
- Updated logout flow to include CSRF token as hidden form field
- Added Thymeleaf namespace to login.html and included CSRF token in login form

### Configuration & Dependencies
- Configured HikariCP connection pool with explicit sizing and timeouts
- Updated `application.properties` to use environment variable placeholders
- Created test-specific `application-test.properties` (referenced but not shown in diff)

https://claude.ai/code/session_01JE2UoV6Rr3EAvUC3o6zv6t